### PR TITLE
ci: ensure jsdoc on all exported lib elements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "ignorePatterns": ["**/*"],
   "parser": "@typescript-eslint/parser",
   "plugins": [
+    "jsdoc",
     "@nx",
     "sonarjs",
     "deprecation",

--- a/libs/smart-ngrx/.eslintrc.json
+++ b/libs/smart-ngrx/.eslintrc.json
@@ -8,6 +8,11 @@
         "project": ["./tsconfig.*?.json"]
       },
       "rules": {
+        // JSDoc Plugin
+        "jsdoc/require-description": "error",
+        "jsdoc/require-param": "error",
+        "jsdoc/require-returns": "error",
+        // Turn off rules for lib
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/explicit-function-return-type": "off"

--- a/libs/smart-ngrx/.eslintrc.json
+++ b/libs/smart-ngrx/.eslintrc.json
@@ -12,6 +12,20 @@
         "jsdoc/require-description": "error",
         "jsdoc/require-param": "error",
         "jsdoc/require-returns": "error",
+        "jsdoc/require-hyphen-before-param-description": ["error", "never"],
+        "jsdoc/require-jsdoc": [
+          "error",
+          {
+            "publicOnly": true,
+            "require": {
+              "FunctionDeclaration": true,
+              "MethodDefinition": true,
+              "ClassDeclaration": true,
+              "ArrowFunctionExpression": true,
+              "FunctionExpression": true
+            }
+          }
+        ],
         // Turn off rules for lib
         "@typescript-eslint/no-unsafe-assignment": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/libs/smart-ngrx/src/common/assert.function.ts
+++ b/libs/smart-ngrx/src/common/assert.function.ts
@@ -26,8 +26,8 @@
  * // now use the variable without having to use ? or ! everywhere
  * ```
  *
- * @param condition - condition to check
- * @param context - description of what we checked.
+ * @param condition condition to check
+ * @param context description of what we checked.
  *                  If you put a GUID in the string it will
  *                  make it easier to find the error in the
  *                  source code.

--- a/libs/smart-ngrx/src/effects/buffer-action.function.ts
+++ b/libs/smart-ngrx/src/effects/buffer-action.function.ts
@@ -64,8 +64,8 @@ function mainBuffer(
       { functional: true }
     );
  * ```
- * @param ngZone - The zone to use to run outside of Angular.
- * @param bufferTime - The time to buffer the ids before sending them to the server.
+ * @param ngZone The zone to use to run outside of Angular.
+ * @param bufferTime The time to buffer the ids before sending them to the server.
  *     The default is 1ms which only allow the buffer to last until the thread frees up
  *     and is probably all we will ever need.
  * @returns The buffered ids.

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
@@ -9,8 +9,8 @@ import { EffectService } from '../effect-service';
 /**
  * This is the effect that loads the ids from the service.
  *
- * @param effectServiceToken - the effect service token that knows how to load the ids
- * @param actions - the action group for the source provided
+ * @param effectServiceToken the effect service token that knows how to load the ids
+ * @param actions the action group for the source provided
  * @returns the loadByIds effect
  */
 export function loadByIdsEffect<T>(

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
@@ -11,7 +11,7 @@ import { EffectService } from '../effect-service';
  *
  * @param effectServiceToken - the effect service token that knows how to load the ids
  * @param actions - the action group for the source provided
- * @returns
+ * @returns the loadByIds effect
  */
 export function loadByIdsEffect<T>(
   effectServiceToken: InjectionToken<EffectService<T>>,

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
@@ -9,7 +9,7 @@ import { bufferAction } from '../buffer-action.function';
  * This is the effect that queues up the ids so the dummy records can be
  * loaded into the store while the service is retrieving the real records.
  * @param actions - the action group for the source provided
- * @returns
+ * @returns the LoadByIdesPreload effect
  */
 export function loadByIdsPreloadEffect<T>(actions: ActionGroup<T>) {
   return (actions$ = inject(Actions), zone: NgZone = inject(NgZone)) => {

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
@@ -8,7 +8,7 @@ import { bufferAction } from '../buffer-action.function';
 /**
  * This is the effect that queues up the ids so the dummy records can be
  * loaded into the store while the service is retrieving the real records.
- * @param actions - the action group for the source provided
+ * @param actions the action group for the source provided
  * @returns the LoadByIdesPreload effect
  */
 export function loadByIdsPreloadEffect<T>(actions: ActionGroup<T>) {

--- a/libs/smart-ngrx/src/effects/effects-factory/load-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-effect.function.ts
@@ -10,6 +10,7 @@ import { EffectService } from '../effect-service';
  *
  * @param effectServiceToken - Token for the effect service that loads the data
  * @param actions - The action group for the source provided
+ * @returns The load effect
  */
 export function loadEffect<T>(
   effectServiceToken: InjectionToken<EffectService<T>>,

--- a/libs/smart-ngrx/src/effects/effects-factory/load-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-effect.function.ts
@@ -8,8 +8,8 @@ import { EffectService } from '../effect-service';
 /**
  * This is an internal function that defines the load effect
  *
- * @param effectServiceToken - Token for the effect service that loads the data
- * @param actions - The action group for the source provided
+ * @param effectServiceToken Token for the effect service that loads the data
+ * @param actions The action group for the source provided
  * @returns The load effect
  */
 export function loadEffect<T>(

--- a/libs/smart-ngrx/src/effects/effects.factory.ts
+++ b/libs/smart-ngrx/src/effects/effects.factory.ts
@@ -14,8 +14,8 @@ import { loadEffect } from './effects-factory/load-effect.function';
  * `Action` source provided and calls the service represented
  * by the `InjectionToken` provided.
  *
- * @param source - The source of the actions for this effect
- * @param effectsServiceToken - The token for the service that
+ * @param source The source of the actions for this effect
+ * @param effectsServiceToken The token for the service that
  *   the resulting effect will call.
  * @returns The effect for the source provided
  *

--- a/libs/smart-ngrx/src/effects/effects.factory.ts
+++ b/libs/smart-ngrx/src/effects/effects.factory.ts
@@ -15,7 +15,7 @@ import { loadEffect } from './effects-factory/load-effect.function';
  * by the `InjectionToken` provided.
  *
  * @param source - The source of the actions for this effect
- * @param effectServiceToken - The token for the service that
+ * @param effectsServiceToken - The token for the service that
  *   the resulting effect will call.
  * @returns The effect for the source provided
  *

--- a/libs/smart-ngrx/src/functions/action.factory.ts
+++ b/libs/smart-ngrx/src/functions/action.factory.ts
@@ -18,7 +18,7 @@ const actionGroupCache = new Map<string, CachedActionGroup>();
  * dispatch one of these actions from your own code. They
  * are used internally and are only exposed for convenience.
  *
- * @param source - The source of the actions for this effect
+ * @param source The source of the actions for this effect
  * @returns The action group for the source provided
  *
  * @see `IdProp`

--- a/libs/smart-ngrx/src/functions/provide-smart-feature-entities.function.ts
+++ b/libs/smart-ngrx/src/functions/provide-smart-feature-entities.function.ts
@@ -24,9 +24,9 @@ import { registerEntity } from './register-entity.function';
  *     ...
  *   ],
  * ```
- * @param featureName - This is the name you would use for forFeature()
+ * @param featureName This is the name you would use for forFeature()
  * in standard NgRX code.
- * @param entityDefinitions - An array of entity definitions.
+ * @param entityDefinitions An array of entity definitions.
  * @returns `EnvironmentProviders` that will get used to provide the NgRX reducer and effect for this slice.
  *
  * @see `EntityDefinition`

--- a/libs/smart-ngrx/src/reducers/default-rows.function.ts
+++ b/libs/smart-ngrx/src/reducers/default-rows.function.ts
@@ -3,9 +3,9 @@ import { EntityState } from '@ngrx/entity';
 /**
  * Filters out the rows we already have and provides a default row
  * for the ones we don't have.
- * @param ids - The ids to check
- * @param state - The current state to check ids against
- * @param defaultRow - The defaultRow function to use to
+ * @param ids The ids to check
+ * @param state The current state to check ids against
+ * @param defaultRow The defaultRow function to use to
  * create a new row for the ids that are missing.
  * @returns The default rows for the ids that are missing
  */

--- a/libs/smart-ngrx/src/reducers/reducer.factory.ts
+++ b/libs/smart-ngrx/src/reducers/reducer.factory.ts
@@ -10,8 +10,8 @@ import { defaultRows } from './default-rows.function';
  * and documented here for future contributions. Application code
  * should never need to use this function.
  *
- * @param source - The source of the actions for this effect
- * @param defaultRow - A function that returns a default row for the given id
+ * @param source The source of the actions for this effect
+ * @param defaultRow A function that returns a default row for the given id
  * @returns a new reducer for the source provided
  */
 export function reducerFactory<Source extends string, T>(

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -10,10 +10,6 @@ import { isArrayProxy } from './is-array-proxy.function';
  * This is an internal class used by `createSmartSelector` to wrap the field
  * that represents the child array with a class that manages all the
  * magic of loading the data from the server as it is accessed.
- * @param childArray The array of ids to wrap
- * @param child The child entity we use to find the item in the store
- * @param childAction the action to fire if the item has not been loaded
- * @param defaultChildRow function that returns a default row for the child
  *
  * @see `createSmartSelector`
  */
@@ -26,6 +22,14 @@ export class ArrayProxy<C extends MarkAndDelete> implements ArrayLike<C> {
   private childAction: (p: { ids: string[] }) => Action;
   private defaultChildRow: (id: string) => C;
 
+  /**
+   * The constructor for the ArrayProxy class.
+   *
+   * @param childArray The array of ids to wrap
+   * @param child The child entity we use to find the item in the store
+   * @param childAction the action to fire if the item has not been loaded
+   * @param defaultChildRow function that returns a default row for the child
+   */
   constructor(
     childArray: ArrayProxy<C> | string[],
     child: EntityState<C>,
@@ -48,6 +52,11 @@ export class ArrayProxy<C extends MarkAndDelete> implements ArrayLike<C> {
     });
   }
 
+  /**
+   * This initialized the class once it has been created. We do this
+   * so that we can test the class without having to worry about
+   * executable code in the constructor.
+   */
   init(): void {
     // fill childArray with values from entity that we currently have
     if (isArrayProxy(this.childArray)) {
@@ -67,7 +76,8 @@ export class ArrayProxy<C extends MarkAndDelete> implements ArrayLike<C> {
    * This primarily exist for testing so you can stringify the array and then
    * parse it so that you get an array you can compare against instead of an
    * object of type ArrayProxy that you can't do much with.
-   * @returns
+   * @returns what this would return if it were a real array.  Mostly for
+   * unit testing.
    */
   toJSON(): C[] {
     const array: C[] = [];
@@ -80,7 +90,15 @@ export class ArrayProxy<C extends MarkAndDelete> implements ArrayLike<C> {
   [n: number]: C;
   length = 0;
 
-  // Getter for data retrieval
+  /**
+   * Allows us to go after the data in the store based on the index of the
+   * array.
+   *
+   * @param index the index into the rawArray that has the ID we will
+   * lookup in the entity.
+   * @returns the item from the store or the default row if it is not in the
+   * store yet.
+   */
   getAtIndex(index: number): C {
     if (index >= 0 && index < this.rawArray.length) {
       const id = this.rawArray[index];

--- a/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
@@ -21,8 +21,8 @@ import { ParentSelector } from './parent-selector.type';
  * that uses virtual data, the proxy adds support for a rawArray property that returns the
  * original array before it was proxied.
  *
- * @param parentSelector - The selector to retrieve the parent data from the store.
- * @param childDefinition - @ProxyChild that defines what the child should look like
+ * @param parentSelector The selector to retrieve the parent data from the store.
+ * @param childDefinition @ProxyChild that defines what the child should look like
  * @returns - an entity with the specified childArray proxies so that when an element is
  *         accessed, the childAction will be dispatched to request data from the server.
  *
@@ -30,8 +30,6 @@ import { ParentSelector } from './parent-selector.type';
  * @see `ProxyChild`
  * @see `ParentSelector`
  */
-
-// eslint-disable-next-line ngrx/prefix-selectors-with-select -- it isn't a selector
 export function createInnerSmartSelector<
   P extends object,
   C extends MarkAndDelete,

--- a/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
@@ -26,10 +26,10 @@ import { ParentSelector } from './parent-selector.type';
  * @see `ParentSelector`
  */
 export function createSmartSelector<P extends object>(
-  parent: ParentSelector<P>,
+  parentSelector: ParentSelector<P>,
   children: ProxyChild<P>[],
 ): MemoizedSelector<object, EntityState<P>> {
   return children.reduce((p, child) => {
     return createInnerSmartSelector(p, child);
-  }, parent);
+  }, parentSelector);
 }

--- a/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
@@ -15,9 +15,9 @@ import { ParentSelector } from './parent-selector.type';
  * support for a rawArray property that returns the original array
  * before it was proxied.
  *
- * @param parentSelector - The selector to retrieve the parent data
+ * @param parentSelector The selector to retrieve the parent data
  * from the store.
- * @param children - The array of `ProxyChild` objects that define the
+ * @param children The array of `ProxyChild` objects that define the
  * child data to retrieve.
  * @returns Memozied selector that returns the proxied arrays.  It is
  * typed as a regular Selector to keep the compiler happy.

--- a/libs/smart-ngrx/src/selector/is-array-proxy.function.ts
+++ b/libs/smart-ngrx/src/selector/is-array-proxy.function.ts
@@ -2,6 +2,12 @@ import { castTo } from '../common/cast-to.function';
 import { MarkAndDelete } from '../types/mark-and-delete.interface';
 import { ArrayProxy } from './array-proxy.class';
 
+// eslint-disable-next-line jsdoc/require-returns -- this is a type guard
+/**
+ * Determines if the specified object is an ArrayProxy
+ *
+ * @param arr the object to check
+ */
 export function isArrayProxy(arr: unknown): arr is ArrayProxy<MarkAndDelete> {
   return !!castTo<ArrayProxy<MarkAndDelete>>(arr).θisProxyθ;
 }

--- a/libs/smart-ngrx/src/selector/mocks/entity-state.factory.ts
+++ b/libs/smart-ngrx/src/selector/mocks/entity-state.factory.ts
@@ -50,7 +50,7 @@ const reduceEntityArrayToObject = (
 /**
  * Used by unit tests to create a mock entity state.
  *
- * @param params - The parameters to use to create the mock entity state.
+ * @param params The parameters to use to create the mock entity state.
  *
  * @returns
  */

--- a/libs/smart-ngrx/src/selector/mocks/entity-state.factory.ts
+++ b/libs/smart-ngrx/src/selector/mocks/entity-state.factory.ts
@@ -48,17 +48,22 @@ const reduceEntityArrayToObject = (
 });
 
 /**
- * Used by unit tests
- * @param param0
+ * Used by unit tests to create a mock entity state.
+ *
+ * @param params - The parameters to use to create the mock entity state.
+ *
  * @returns
  */
-export function entityStateFactory({
-  parentCount,
-  childCount,
-  parentType,
-  childType,
-  isDirty = false,
-}: EntityStateFactoryParameters): EntityState<Entity> {
+export function entityStateFactory(
+  params: EntityStateFactoryParameters,
+): EntityState<Entity> {
+  const {
+    parentCount,
+    childCount,
+    parentType,
+    childType,
+    isDirty = false,
+  } = params;
   const ids = Array(parentCount)
     .fill(0)
     .map((_, i) => `${parentType}-${i + 1}`);

--- a/libs/smart-ngrx/src/selector/store.effects.ts
+++ b/libs/smart-ngrx/src/selector/store.effects.ts
@@ -8,6 +8,10 @@ import { store } from './store.function';
  */
 @Injectable()
 export class StoreEffects {
+  /**
+   * This is the constructor that is used to set the global store.
+   * @param storeInstance
+   */
   constructor(
     // eslint-disable-next-line ngrx/use-consistent-global-store-name -- this is needed because we are calling the function store()
     storeInstance: Store,

--- a/libs/smart-ngrx/src/selector/store.function.ts
+++ b/libs/smart-ngrx/src/selector/store.function.ts
@@ -12,13 +12,14 @@ export let globalStore: Store | undefined;
  * Internal function used to provide and retrieve a global store
  * that is needed by code that does not have DI.
  *
- * @param storeParam - This is an optional parameter.  If it is there,
+ * @param storeParam This is an optional parameter.  If it is there,
  *     we set the store.  Otherwise, we use what is already set.
  * @returns = the global store value.
  */
-
-// eslint-disable-next-line ngrx/use-consistent-global-store-name -- it is either this or get a shadowing lint issue
-export function store(storeParam?: Store): Store | undefined {
+export function store(
+  // eslint-disable-next-line ngrx/use-consistent-global-store-name -- it is either this or get a shadowing lint issue
+  storeParam?: Store,
+): Store | undefined {
   if (storeParam) {
     globalStore = storeParam;
   }

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-functional": "6.0.0",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-jest": "27.6.0",
+    "eslint-plugin-jsdoc": "^46.9.0",
     "eslint-plugin-max-params-no-constructor": "0.0.4",
     "eslint-plugin-ngrx": "2.1.4",
     "eslint-plugin-rxjs": "5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ devDependencies:
   eslint-plugin-jest:
     specifier: 27.6.0
     version: 27.6.0(@typescript-eslint/eslint-plugin@6.11.0)(eslint@8.54.0)(jest@29.7.0)(typescript@5.2.2)
+  eslint-plugin-jsdoc:
+    specifier: ^46.9.0
+    version: 46.9.0(eslint@8.54.0)
   eslint-plugin-max-params-no-constructor:
     specifier: 0.0.4
     version: 0.0.4
@@ -2557,6 +2560,15 @@ packages:
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+
+  /@es-joy/jsdoccomment@0.41.0:
+    resolution: {integrity: sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==}
+    engines: {node: '>=16'}
+    dependencies:
+      comment-parser: 1.4.1
+      esquery: 1.5.0
+      jsdoc-type-pratt-parser: 4.0.0
+    dev: true
 
   /@esbuild/android-arm64@0.17.8:
     resolution: {integrity: sha512-oa/N5j6v1svZQs7EIRPqR8f+Bf8g6HBDjD/xHC02radE/NjKHK7oQmtmLxPs1iVwYyvE+Kolo6lbpfEQ9xnhxQ==}
@@ -6897,6 +6909,11 @@ packages:
   /arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
 
+  /are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+    dev: true
+
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -7939,6 +7956,11 @@ packages:
       esprima: 4.0.1
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
+    dev: true
+
+  /comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
     dev: true
 
   /common-path-prefix@3.0.0:
@@ -9335,6 +9357,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /eslint-plugin-jsdoc@46.9.0(eslint@8.54.0):
+    resolution: {integrity: sha512-UQuEtbqLNkPf5Nr/6PPRCtr9xypXY+g8y/Q7gPa0YK7eDhh0y2lWprXRnaYbW7ACgIUvpDKy9X2bZqxtGzBG9Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@es-joy/jsdoccomment': 0.41.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.3.4(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint: 8.54.0
+      esquery: 1.5.0
+      is-builtin-module: 3.2.1
+      semver: 7.5.4
+      spdx-expression-parse: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-max-params-no-constructor@0.0.4:
@@ -11811,6 +11853,11 @@ packages:
       commander: 5.1.0
       fs-extra: 9.1.0
       gitignore-to-glob: 0.3.0
+    dev: true
+
+  /jsdoc-type-pratt-parser@4.0.0:
+    resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
+    engines: {node: '>=12.0.0'}
     dev: true
 
   /jsdom@20.0.3:


### PR DESCRIPTION
# Issue Number: #203 

# Body

Adds lint rules to the lib that ensures JSDoc is provided for all exported items
