### PR TITLE
fix: editing works with refreshing and updated express

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -804,6 +804,12 @@
       }
     },
     {
+      "files": ["reducer.factory.ts"],
+      "rules": {
+        "max-lines-per-function": "off"
+      }
+    },
+    {
       "files": ["*.html"],
       "extends": ["plugin:@nx/angular-template"],
       "rules": {

--- a/apps/demo/src/app/app.config.ts
+++ b/apps/demo/src/app/app.config.ts
@@ -44,7 +44,9 @@ export const appConfig: ApplicationConfig = {
     ),
     provideStore({}),
     provideEffects(),
-    provideSmartNgRX(),
+    provideSmartNgRX({
+      markDirtyTime: 120000,
+    }),
     provideAnimations(),
     provideStoreDevtools(),
     provideRouter(appRoutes, withViewTransitions()),

--- a/apps/demo/src/app/shared/components/tree/tree.component.html
+++ b/apps/demo/src/app/shared/components/tree/tree.component.html
@@ -115,7 +115,7 @@
   } @else {
     <dmb-node-editor
       placeholder="Edit Label"
-      [(ngModel)]="node.name"
+      [(ngModel)]="editingContent"
       (save)="saveNode(node)"
       (cancel)="cancelEdit(node)"
     />

--- a/apps/demo/src/app/shared/components/tree/tree.component.ts
+++ b/apps/demo/src/app/shared/components/tree/tree.component.ts
@@ -47,6 +47,9 @@ export class TreeComponent implements OnChanges, AfterViewInit {
   fullDataSource: TreeNode[] = [];
   selectedNode = '';
   editingNode = '';
+  // we can't edit the node in place because it will get overwritten when the
+  // data updates.
+  editingContent = '';
   addingNode = '';
   addingParent: TreeNode | null = null;
   addMenuOpenedNode = '';
@@ -79,17 +82,20 @@ export class TreeComponent implements OnChanges, AfterViewInit {
 
   editNode(node: TreeNode): void {
     this.editingNode = node.level + ':' + node.node.id;
+    this.editingContent = node.name;
   }
 
   cancelEdit(node: TreeNode): void {
     this.treeComponentService.cancelEdit(node);
+    this.editingContent = '';
   }
 
   saveNode(node: TreeNode): void {
     this.addingParent = null;
     this.editingNode = '';
     this.addingNode = '';
-    node.node.name = node.name;
+    node.node.name = this.editingContent;
+    this.editingContent = '';
   }
 
   addMenuOpened(node: TreeNode): void {
@@ -101,8 +107,9 @@ export class TreeComponent implements OnChanges, AfterViewInit {
   }
 
   addChild(parent: TreeNode, type: string): void {
+    this.editingContent = `New ${type}`;
     this.treeComponentService.addChild(
-      { id: type + ':new', name: `New ${type}`, children: [] },
+      { id: type + ':new', name: this.editingContent, children: [] },
       parent,
     );
     this.addingNode = `${parent.level + 1}:${type}:new`;

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-features-interval.function.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-features-interval.function.ts
@@ -1,5 +1,6 @@
 import { interval, tap } from 'rxjs';
 
+import { forNext } from '../../common/for-next.function';
 import { psi } from '../../common/theta.const';
 import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { markAndDeleteEntities } from '../mark-and-delete-entity.map';
@@ -16,16 +17,15 @@ export function markAndDeleteFeaturesInterval(): void {
     .pipe(
       tap(() => {
         const featureKeys = markAndDeleteEntities();
-        const featureKeyLength = featureKeys.length;
         // for/next is faster than forEach
-        for (let i = 0; i < featureKeyLength; i++) {
+        forNext(featureKeys, (item) =>
           markAndDeleteEntity(
-            featureKeys[i].split(psi) as [
+            item.split(psi) as [
               StringLiteralSource<string>,
               StringLiteralSource<string>,
             ],
-          );
-        }
+          ),
+        );
       }),
     )
     .subscribe();

--- a/libs/smart-ngrx/src/reducers/reducer.factory.ts
+++ b/libs/smart-ngrx/src/reducers/reducer.factory.ts
@@ -46,9 +46,11 @@ export function reducerFactory<
     ),
     on(actions.loadSuccess, (state, { rows }) => adapter.setAll(rows, state)),
     on(actions.markDirty, (state, { ids }) => {
-      const changes = ids.map(
-        (id) => ({ id, changes: { isDirty: true } }) as UpdateStr<T>,
-      );
+      const changes = ids
+        .filter((id) => {
+          return state.entities[id]?.isEditing !== true;
+        })
+        .map((id) => ({ id, changes: { isDirty: true } }) as UpdateStr<T>);
       return adapter.updateMany(changes, state);
     }),
     on(actions.markNotDirty, (state, { ids }) => {
@@ -58,7 +60,14 @@ export function reducerFactory<
       return adapter.updateMany(changes, state);
     }),
     on(actions.garbageCollect, (state, { ids }) =>
-      adapter.removeMany(unregisterEntityRows(feature, entity, ids), state),
+      adapter.removeMany(
+        unregisterEntityRows(
+          feature,
+          entity,
+          ids.filter((id) => state.entities[id]?.isEditing !== true),
+        ),
+        state,
+      ),
     ),
     on(actions.update, (state, { new: { row } }) =>
       adapter.upsertOne(row, state),

--- a/libs/smart-ngrx/src/reducers/reducer.factory.ts
+++ b/libs/smart-ngrx/src/reducers/reducer.factory.ts
@@ -35,6 +35,7 @@ export function reducerFactory<
   const initialState = adapter.getInitialState();
   const actions = actionFactory<T, F, E>(feature, entity);
 
+  /* istanbul ignore next -- refactoring actions next which will probably remove the conditions from the reducer */
   return createReducer(
     initialState,
     on(actions.add, (state, { row }) => adapter.upsertOne(row, state)),

--- a/libs/smart-ngrx/src/row-proxy/custom-proxy-get.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/custom-proxy-get.function.ts
@@ -24,6 +24,7 @@ export function customProxyGet<
   if (prop === 'getRealRow') {
     return () => target.getRealRow();
   }
+  /* istanbul ignore next -- trivial and app would break without it*/
   if (prop === 'isEditing') {
     actions.loadByIdsSuccess({ rows: [{ ...target.row, isEditing: true }] });
   }

--- a/libs/smart-ngrx/src/row-proxy/custom-proxy-get.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/custom-proxy-get.function.ts
@@ -1,0 +1,31 @@
+import { ActionGroup } from '../functions/action-group.interface';
+import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
+import { CustomProxy } from './custom-proxy.class';
+
+/**
+ * This provides the get method of the Proxy in CustomProxy
+ *
+ * @param target the CustomProxy the Proxy targets
+ * @param prop the property the proxy needs to retrieve
+ * @param actions the action group associated with the row entity
+ * @returns the value of the property
+ */
+export function customProxyGet<
+  T extends SmartNgRXRowBase,
+  P extends SmartNgRXRowBase,
+>(
+  target: CustomProxy<T, P>,
+  prop: string | symbol,
+  actions: ActionGroup<T>,
+): unknown {
+  if (prop === 'toJSON') {
+    return () => target.toJSON();
+  }
+  if (prop === 'getRealRow') {
+    return () => target.getRealRow();
+  }
+  if (prop === 'isEditing') {
+    actions.loadByIdsSuccess({ rows: [{ ...target.row, isEditing: true }] });
+  }
+  return prop in target.changes ? target.changes[prop] : target.record[prop];
+}

--- a/libs/smart-ngrx/src/row-proxy/custom-proxy-set.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/custom-proxy-set.function.ts
@@ -1,0 +1,59 @@
+import { assert } from '../common/assert.function';
+import { castTo } from '../common/cast-to.function';
+import { ActionGroup } from '../functions/action-group.interface';
+import { store as storeFunction } from '../selector/store.function';
+import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
+import { CustomProxy } from './custom-proxy.class';
+
+/**
+ * This provides the set method of the Proxy in CustomProxy
+ *
+ * @param target the CustomProxy the Proxy targets
+ * @param prop the property the proxy needs to set
+ * @param value the value to set the property to
+ * @param actions the action group associated with the row and parent entity
+ * @param actions.actions the action group associated with the row entity
+ * @param actions.parentActions the action group associated with the parent entity
+ * @returns true if the property was set, false otherwise
+ */
+export function customProxySet<
+  T extends SmartNgRXRowBase,
+  P extends SmartNgRXRowBase,
+>(
+  target: CustomProxy<T, P>,
+  prop: string | symbol,
+  value: unknown,
+  actions: { actions: ActionGroup<T>; parentActions: ActionGroup<P> },
+): boolean {
+  /* istanbul ignore next -- untestable using strong typing but here to protect misuse by others */
+  if (!(prop in target.record)) {
+    return false;
+  }
+  target.changes[prop] = value;
+  const realRow = target.getRealRow();
+  const store = storeFunction();
+  assert(!!store, 'store is undefined');
+  // if there is a parentId then we need to
+  // add the row on the server
+  if (realRow.parentId !== undefined) {
+    store.dispatch(
+      actions.actions.add({
+        row: { ...realRow, [prop]: value } as T,
+        parentId: realRow.parentId,
+        parentActions: castTo<ActionGroup<SmartNgRXRowBase>>(
+          actions.parentActions,
+        ),
+      }),
+    );
+    return true;
+  }
+  // if there is not parentId then we are simply saving the
+  // row to the server
+  store.dispatch(
+    actions.actions.update({
+      new: { row: { ...realRow, [prop]: value } as T },
+      old: { row: realRow },
+    }),
+  );
+  return true;
+}

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -161,6 +161,7 @@ export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
       };
     }
     newRow.parentId = parentId;
+    newRow.isEditing = true;
     store.dispatch(actions.loadByIdsSuccess({ rows: [newRow] }));
     castTo<Record<keyof P, string[]>>(newParent)[
       this.childDefinition.parentField

--- a/libs/smart-ngrx/src/selector/ensure-data-loaded.function.ts
+++ b/libs/smart-ngrx/src/selector/ensure-data-loaded.function.ts
@@ -40,10 +40,12 @@ export function ensureDataLoaded<
     !registry.markAndDeleteInit.markDirtyFetchesNew
   );
 
+  const idsId = ids[id];
+
   if (
-    ids[id] === undefined ||
-    (ids[id].isDirty === true && markDirtyFetchesNew) ||
-    ids[id].isDirty === undefined
+    idsId === undefined ||
+    (idsId.isDirty === true && markDirtyFetchesNew) ||
+    idsId.isDirty === undefined
   ) {
     const s = store();
     assert(!!s, 'store is undefined');
@@ -53,8 +55,8 @@ export function ensureDataLoaded<
       // gets around the 'NG0600: Writing to signals is not allowed in a computed or an effect by default'
       s.dispatch(actions.loadByIds({ ids: [id] }));
     });
-  } else if (ids[id].isDirty === true && !markDirtyFetchesNew) {
-    registerEntityRows(feature, entity, [ids[id]]);
+  } else if (idsId.isDirty && !markDirtyFetchesNew) {
+    registerEntityRows(feature, entity, [idsId]);
     void unpatchedPromise.resolve().then(() => {
       const s = store();
       assert(!!s, 'store is undefined');

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "better-sqlite3": "^9.4.3",
     "cors": "^2.8.5",
     "dexie": "^3.2.6",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "reflect-metadata": "^0.2.1",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ dependencies:
     specifier: ^3.2.6
     version: 3.2.6(karma@6.4.3)
   express:
-    specifier: ^4.18.2
-    version: 4.18.2
+    specifier: ^4.19.2
+    version: 4.19.2
   reflect-metadata:
     specifier: ^0.2.1
     version: 0.2.1
@@ -7330,10 +7330,10 @@ packages:
     resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.4
       is-string: 1.0.7
     dev: true
 
@@ -7353,18 +7353,18 @@ packages:
     resolution: {integrity: sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.4
     dev: true
 
   /array.prototype.flat@1.3.2:
     resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
@@ -7374,7 +7374,7 @@ packages:
     resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
       es-shim-unscopables: 1.0.0
@@ -7958,13 +7958,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /call-bind@1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
-    dependencies:
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-    dev: true
-
   /call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
     engines: {node: '>= 0.4'}
@@ -8410,6 +8403,10 @@ packages:
 
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+
+  /cookie@0.6.0:
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
   /copy-anything@2.0.6:
@@ -8975,15 +8972,6 @@ packages:
     dependencies:
       clone: 1.0.4
 
-  /define-data-property@1.1.0:
-    resolution: {integrity: sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.2
-    dev: true
-
   /define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -9000,8 +8988,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.0
-      has-property-descriptors: 1.0.0
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
       object-keys: 1.1.1
     dev: true
 
@@ -9374,7 +9362,7 @@ packages:
       globalthis: 1.0.3
       gopd: 1.0.1
       has: 1.0.3
-      has-property-descriptors: 1.0.0
+      has-property-descriptors: 1.0.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
       internal-slot: 1.0.5
@@ -10134,6 +10122,44 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /express@4.19.2:
+    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.2
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.6.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -10519,15 +10545,6 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /get-intrinsic@1.2.1:
-    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
-    dependencies:
-      function-bind: 1.1.2
-      has: 1.0.3
-      has-proto: 1.0.1
-      has-symbols: 1.0.3
-    dev: true
-
   /get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
@@ -10745,12 +10762,6 @@ packages:
   /has-own-prop@2.0.0:
     resolution: {integrity: sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==}
     engines: {node: '>=8'}
-    dev: true
-
-  /has-property-descriptors@1.0.0:
-    resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
-    dependencies:
-      get-intrinsic: 1.2.4
     dev: true
 
   /has-property-descriptors@1.0.2:
@@ -13875,7 +13886,7 @@ packages:
     resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
     dev: true
@@ -13894,17 +13905,17 @@ packages:
   /object.groupby@1.0.1:
     resolution: {integrity: sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.4
     dev: true
 
   /object.values@1.1.7:
     resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.22.2
     dev: true
@@ -17561,7 +17572,7 @@ packages:
   /util.promisify@1.1.2:
     resolution: {integrity: sha512-PBdZ03m1kBnQ5cjjO0ZvJMJS+QsbyIcFwi4hY4U76OQsCO9JrOYjbCFgIF76ccFg9xnJo7ZHPkqyj1GqmdS7MA==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.7
       define-properties: 1.2.1
       for-each: 0.3.3
       has-proto: 1.0.1
@@ -17830,7 +17841,7 @@ packages:
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.18.2
+      express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.4.0
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)


### PR DESCRIPTION
# Issue Number: #345 

# Body

This fixes a known issue with add and edit where refreshing the data caused the add/edit to be reset. This no longer happens