### PR TITLE
refactor: update in the effectservice should not handle rollback

### DIFF
--- a/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
+++ b/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { catchError, forkJoin, map, Observable, of } from 'rxjs';
+import { forkJoin, map, Observable, of } from 'rxjs';
 
 import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
@@ -85,54 +85,49 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
     return { docIds, folderIds, listIds, sprintFolderIds };
   }
 
-  override update: (
-    oldRow: DepartmentChild,
-    newRow: DepartmentChild,
-  ) => Observable<DepartmentChild[]> = (
-    oldRow: DepartmentChild,
-    newRow: DepartmentChild,
-  ) => {
-    const { docIds, folderIds, listIds, sprintFolderIds } = this.bucketId(
-      newRow.id,
-    );
+  override update: (newRow: DepartmentChild) => Observable<DepartmentChild[]> =
+    (newRow: DepartmentChild) => {
+      const { docIds, folderIds, listIds, sprintFolderIds } = this.bucketId(
+        newRow.id,
+      );
 
-    let updateStream: Observable<DepartmentChild[]> = of(
-      [] as DepartmentChild[],
-    );
-    docIds.forEach((id) => {
-      updateStream = updateForType(
-        this.doc,
-        { ...newRow, id },
-        this.docs,
-        'did',
+      let updateStream: Observable<DepartmentChild[]> = of(
+        [] as DepartmentChild[],
       );
-    });
-    folderIds.forEach((id) => {
-      updateStream = updateForType(
-        this.folder,
-        {
-          ...newRow,
-          id,
-        },
-        this.folders,
-      );
-    });
-    listIds.forEach((id) => {
-      updateStream = updateForType(this.list, { ...newRow, id }, this.lists);
-    });
-    sprintFolderIds.forEach((id) => {
-      updateStream = updateForType(
-        this.sprintFolder,
-        {
-          ...newRow,
-          id,
-        },
-        this.sprintFolders,
-      );
-    });
+      docIds.forEach((id) => {
+        updateStream = updateForType(
+          this.doc,
+          { ...newRow, id },
+          this.docs,
+          'did',
+        );
+      });
+      folderIds.forEach((id) => {
+        updateStream = updateForType(
+          this.folder,
+          {
+            ...newRow,
+            id,
+          },
+          this.folders,
+        );
+      });
+      listIds.forEach((id) => {
+        updateStream = updateForType(this.list, { ...newRow, id }, this.lists);
+      });
+      sprintFolderIds.forEach((id) => {
+        updateStream = updateForType(
+          this.sprintFolder,
+          {
+            ...newRow,
+            id,
+          },
+          this.sprintFolders,
+        );
+      });
 
-    return updateStream.pipe(catchError((_: unknown) => of([oldRow])));
-  };
+      return updateStream;
+    };
 
   override add: (row: DepartmentChild) => Observable<DepartmentChild[]> = (
     row: DepartmentChild,

--- a/apps/demo/src/app/shared/department/department-effects.service.ts
+++ b/apps/demo/src/app/shared/department/department-effects.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { catchError, map, Observable, of } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
 
@@ -23,10 +23,9 @@ export class DepartmentEffectsService extends EffectService<Department> {
       .pipe(map(childrenTransform));
   };
 
-  override update: (
-    oldRow: Department,
+  override update: (newRow: Department) => Observable<Department[]> = (
     newRow: Department,
-  ) => Observable<Department[]> = (oldRow: Department, newRow: Department) => {
+  ) => {
     return this.http
       .put<Department[]>(this.apiDepartments, {
         id: newRow.id,
@@ -35,10 +34,6 @@ export class DepartmentEffectsService extends EffectService<Department> {
       .pipe(
         map((departments) => addIsDirty(departments) as Department[]),
         map(childrenTransform),
-        catchError((_: unknown) => {
-          // probably would want to send a message to the user here
-          return of([oldRow]);
-        }),
       );
   };
 

--- a/apps/demo/src/app/shared/locations/location-effects.service.ts
+++ b/apps/demo/src/app/shared/locations/location-effects.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { catchError, Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
 
@@ -23,13 +23,10 @@ export class LocationEffectsService extends EffectService<Location> {
     return this.http.post<Location[]>(this.apiLocation, ids);
   };
 
-  override update: (
-    oldRow: Location,
+  override update: (newRow: Location) => Observable<Location[]> = (
     newRow: Location,
-  ) => Observable<Location[]> = (oldRow: Location, newRow: Location) => {
-    return this.http
-      .put<Location[]>(this.apiLocation, newRow)
-      .pipe(catchError(() => of([oldRow])));
+  ) => {
+    return this.http.put<Location[]>(this.apiLocation, newRow);
   };
 
   override add: (row: Location) => Observable<Location[]> = (row: Location) => {

--- a/apps/demo/src/app/shared/top/top-effects.service.ts
+++ b/apps/demo/src/app/shared/top/top-effects.service.ts
@@ -20,10 +20,7 @@ export class TopEffectsService extends EffectService<Top> {
     return this.http.post<Top[]>(this.apiTop, ids);
   };
 
-  override update: (oldRow: Top, newRow: Top) => Observable<Top[]> = (
-    _: Top,
-    __: Top,
-  ) => {
+  override update: (newRow: Top) => Observable<Top[]> = (_: Top) => {
     return of([]);
   };
 

--- a/apps/documentation/src/app/using-smart-ng-rx/crud-support/updates/index.md
+++ b/apps/documentation/src/app/using-smart-ng-rx/crud-support/updates/index.md
@@ -9,31 +9,16 @@ As an example, here is how we've updated the `update` method in the `DepartmentE
 > **Note:** explanation of this code will follow the code snippet.
 
 ```typescript
-  override update: (
-    oldRow: Department,
-    newRow: Department,
-  ) => Observable<Department[]> = (oldRow: Department, newRow: Department) => {
-    return this.http
-      .put<Department[]>('./api/departments', {
-        id: newRow.id,
-        name: newRow.name,
-      })
-      .pipe(
-        map((departments) => addIsDirty(departments) as Department[]),
-        map(childrenTransform),
-        catchError((_: unknown) => {
-          // probably would want to send a message to the user here
-          return of([oldRow]);
-        }),
-      );
-  };
+override update: (newRow: Location) => Observable<Location[]> = (
+  newRow: Location,
+) => {
+  return this.http.put<Location[]>(this.apiLocation, newRow);
+};
 ```
 
-The first thing you will note is that the method takes two parameters, `oldRow` and `newRow`. The `oldRow` is the row that was in the store before the update was requested. The `newRow` is the row that was passed in to the `update` method. This allows you to roll back the update if the update fails as we do in the `catchError` block.
+Everything is handled for you including optimistic updates of the store and rollbacks as required.
 
 This needs a bit of explanation. The effect that calls this service keeps track of the row that was updated. Instead of using switchMap() around our call to this service, we use concatMap(). By doing this, if a call fails, we can rollback each call so that when the next call comes in, the row is in the state is was prior to the update that just failed.
-
-So, just like we've done here, you want to catch errors and return the old row. Whatever is in the return value row is what we'll use to pass in to the next update for the same row.
 
 Also, notice that we always return an array of rows even though there should only ever be one row in the array. This allows us to reuse code that we used previously to get the list of rows from the server. You'll see that in our implementation on the server, we reuse the getByIds code to get the row we just updated.
 

--- a/libs/smart-ngrx/src/effects/effect-service.ts
+++ b/libs/smart-ngrx/src/effects/effect-service.ts
@@ -13,7 +13,7 @@ export abstract class EffectService<T> {
   /**
    * Sends the updated row in the store to the server.
    */
-  abstract update: (oldRow: T, newRow: T) => Observable<T[]>;
+  abstract update: (newRow: T) => Observable<T[]>;
 
   /**
    * Sends a new row to the server


### PR DESCRIPTION
# Issue Number: #414 

# Body

Updated the update method in the Effect Service to only take the new row as a parameter. Rollbacks are now handled in the effect that calls this service.

Also updated documentation for update.