### PR TITLE
refactor: update Effect Services to standard class syntax

### DIFF
--- a/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
+++ b/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
@@ -30,9 +30,7 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
   private listPrefix = 'lists:';
   private lists = 'lists';
 
-  override loadByIds: (ids: string[]) => Observable<DepartmentChild[]> = (
-    ids: string[],
-  ) => {
+  override loadByIds(ids: string[]): Observable<DepartmentChild[]> {
     const docIds = filterIds(ids, this.docPrefix);
     const folderIds = filterIds(ids, this.folderPrefix);
     const listIds = filterIds(ids, this.listPrefix);
@@ -69,7 +67,7 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
         ...sprintFolders,
       ]),
     );
-  };
+  }
 
   bucketId(id: string): {
     docIds: string[];
@@ -85,49 +83,48 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
     return { docIds, folderIds, listIds, sprintFolderIds };
   }
 
-  override update: (newRow: DepartmentChild) => Observable<DepartmentChild[]> =
-    (newRow: DepartmentChild) => {
-      const { docIds, folderIds, listIds, sprintFolderIds } = this.bucketId(
-        newRow.id,
-      );
+  override update(newRow: DepartmentChild): Observable<DepartmentChild[]> {
+    const { docIds, folderIds, listIds, sprintFolderIds } = this.bucketId(
+      newRow.id,
+    );
 
-      let updateStream: Observable<DepartmentChild[]> = of(
-        [] as DepartmentChild[],
+    let updateStream: Observable<DepartmentChild[]> = of(
+      [] as DepartmentChild[],
+    );
+    docIds.forEach((id) => {
+      updateStream = updateForType(
+        this.doc,
+        { ...newRow, id },
+        this.docs,
+        'did',
       );
-      docIds.forEach((id) => {
-        updateStream = updateForType(
-          this.doc,
-          { ...newRow, id },
-          this.docs,
-          'did',
-        );
-      });
-      folderIds.forEach((id) => {
-        updateStream = updateForType(
-          this.folder,
-          {
-            ...newRow,
-            id,
-          },
-          this.folders,
-        );
-      });
-      listIds.forEach((id) => {
-        updateStream = updateForType(this.list, { ...newRow, id }, this.lists);
-      });
-      sprintFolderIds.forEach((id) => {
-        updateStream = updateForType(
-          this.sprintFolder,
-          {
-            ...newRow,
-            id,
-          },
-          this.sprintFolders,
-        );
-      });
+    });
+    folderIds.forEach((id) => {
+      updateStream = updateForType(
+        this.folder,
+        {
+          ...newRow,
+          id,
+        },
+        this.folders,
+      );
+    });
+    listIds.forEach((id) => {
+      updateStream = updateForType(this.list, { ...newRow, id }, this.lists);
+    });
+    sprintFolderIds.forEach((id) => {
+      updateStream = updateForType(
+        this.sprintFolder,
+        {
+          ...newRow,
+          id,
+        },
+        this.sprintFolders,
+      );
+    });
 
-      return updateStream;
-    };
+    return updateStream;
+  }
 
   override add: (row: DepartmentChild) => Observable<DepartmentChild[]> = (
     row: DepartmentChild,
@@ -162,7 +159,7 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
     return addStream;
   };
 
-  override delete: (id: string) => Observable<void> = (id: string) => {
+  override delete(id: string): Observable<void> {
     const { docIds, folderIds, listIds, sprintFolderIds } = this.bucketId(id);
 
     let deleteStream: Observable<void> = of(undefined);
@@ -180,5 +177,5 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
     });
 
     return deleteStream;
-  };
+  }
 }

--- a/apps/demo/src/app/shared/department/department-effects.service.ts
+++ b/apps/demo/src/app/shared/department/department-effects.service.ts
@@ -15,17 +15,13 @@ export class DepartmentEffectsService extends EffectService<Department> {
     super();
   }
 
-  override loadByIds: (ids: string[]) => Observable<Department[]> = (
-    ids: string[],
-  ) => {
+  override loadByIds(ids: string[]): Observable<Department[]> {
     return this.http
       .post<Department[]>(this.apiDepartments, ids)
       .pipe(map(childrenTransform));
-  };
+  }
 
-  override update: (newRow: Department) => Observable<Department[]> = (
-    newRow: Department,
-  ) => {
+  override update(newRow: Department): Observable<Department[]> {
     return this.http
       .put<Department[]>(this.apiDepartments, {
         id: newRow.id,
@@ -35,20 +31,16 @@ export class DepartmentEffectsService extends EffectService<Department> {
         map((departments) => addIsDirty(departments) as Department[]),
         map(childrenTransform),
       );
-  };
+  }
 
-  override add: (row: Department) => Observable<Department[]> = (
-    row: Department,
-  ) => {
+  override add(row: Department): Observable<Department[]> {
     return this.http.post<Department[]>(this.apiDepartments + '/add', row).pipe(
       map((departments) => addIsDirty(departments) as Department[]),
       map(childrenTransform),
     );
-  };
+  }
 
-  override delete: (id: string) => Observable<void> = (
-    id: string,
-  ): Observable<void> => {
+  override delete(id: string): Observable<void> {
     return this.http.delete<undefined>(`${this.apiDepartments}/${id}`);
-  };
+  }
 }

--- a/apps/demo/src/app/shared/locations/location-effects.service.ts
+++ b/apps/demo/src/app/shared/locations/location-effects.service.ts
@@ -17,25 +17,19 @@ export class LocationEffectsService extends EffectService<Location> {
     super();
   }
 
-  override loadByIds: (ids: string[]) => Observable<Location[]> = (
-    ids: string[],
-  ) => {
+  override loadByIds(ids: string[]): Observable<Location[]> {
     return this.http.post<Location[]>(this.apiLocation, ids);
-  };
+  }
 
-  override update: (newRow: Location) => Observable<Location[]> = (
-    newRow: Location,
-  ) => {
+  override update(newRow: Location): Observable<Location[]> {
     return this.http.put<Location[]>(this.apiLocation, newRow);
-  };
+  }
 
-  override add: (row: Location) => Observable<Location[]> = (row: Location) => {
+  override add(row: Location): Observable<Location[]> {
     return this.http.post<Location[]>(this.apiLocation, row);
-  };
+  }
 
-  override delete: (id: string) => Observable<void> = (
-    id: string,
-  ): Observable<void> => {
+  override delete(id: string): Observable<void> {
     return this.http.delete<undefined>(`${this.apiLocation}/${id}`);
-  };
+  }
 }

--- a/apps/demo/src/app/shared/top/top-effects.service.ts
+++ b/apps/demo/src/app/shared/top/top-effects.service.ts
@@ -14,21 +14,19 @@ export class TopEffectsService extends EffectService<Top> {
     super();
   }
 
-  override loadByIds: (ids: string[]) => Observable<Top[]> = (
-    ids: string[],
-  ) => {
+  override loadByIds(ids: string[]): Observable<Top[]> {
     return this.http.post<Top[]>(this.apiTop, ids);
-  };
+  }
 
-  override update: (newRow: Top) => Observable<Top[]> = (_: Top) => {
+  override update(_: Top): Observable<Top[]> {
     return of([]);
-  };
+  }
 
-  override add: (row: Top) => Observable<Top[]> = (_: Top) => {
+  override add(_: Top): Observable<Top[]> {
     return of([]);
-  };
+  }
 
-  override delete: (id: string) => Observable<void> = (_: string) => {
+  override delete(_: string): Observable<void> {
     return of();
-  };
+  }
 }

--- a/libs/smart-ngrx/src/effects/effect-service.ts
+++ b/libs/smart-ngrx/src/effects/effect-service.ts
@@ -8,20 +8,20 @@ export abstract class EffectService<T> {
   /**
    * Loads the rows represented by the array of ids passed in from the server
    */
-  abstract loadByIds: (ids: string[]) => Observable<T[]>;
+  abstract loadByIds(ids: string[]): Observable<T[]>;
 
   /**
    * Sends the updated row in the store to the server.
    */
-  abstract update: (newRow: T) => Observable<T[]>;
+  abstract update(newRow: T): Observable<T[]>;
 
   /**
    * Sends a new row to the server
    */
-  abstract add: (row: T) => Observable<T[]>;
+  abstract add(row: T): Observable<T[]>;
 
   /**
    * Deletes the row represented by the id from the server
    */
-  abstract delete: (id: string) => Observable<void>;
+  abstract delete(id: string): Observable<void>;
 }

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
@@ -26,17 +26,17 @@ interface Row extends SmartNgRXRowBase {
   isDirty: boolean;
 }
 class TestService extends EffectService<Row> {
-  override loadByIds: (ids: string[]) => Observable<Row[]> = (_: string[]) => {
+  override loadByIds(_: string[]): Observable<Row[]> {
     return new Observable<Row[]>();
-  };
+  }
 
-  override update: (newRow: Row) => Observable<Row[]> = (newRow: Row) => {
+  override update(newRow: Row): Observable<Row[]> {
     return of([newRow] as Row[]);
-  };
+  }
 
-  override add: (row: Row) => Observable<Row[]> = (_: Row) => {
+  override add(_: Row): Observable<Row[]> {
     return of([] as Row[]);
-  };
+  }
 
   override delete: (id: string) => Observable<void> = (_: string) => {
     return of();


### PR DESCRIPTION
# Issue Number: #484 

# Body

- **Refactor**
  - Simplified method declarations across various services by converting arrow function syntax to standard method syntax.
  - Enhanced readability and consistency in method signatures for better maintenance and understanding.

