### PR TITLE
refactor: reduce casting for code used from demo

### DIFF
--- a/apps/demo/src/app/app.routes.ts
+++ b/apps/demo/src/app/app.routes.ts
@@ -3,7 +3,6 @@ import { Routes } from '@angular/router';
 import { EffectsModule } from '@ngrx/effects';
 import { ActionReducerMap, StoreModule } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { provideSmartFeatureEntities } from '@smart/smart-ngrx/index';
 
 import { watchLocations as watchNoDirtyLocations } from './routes/tree-no-dirty/store/current-location/current-location.effects';
@@ -30,22 +29,22 @@ import { standardDepartmentsDefinition } from './routes/tree-standard/store/depa
 import { standardDepartmentChildrenDefinition } from './routes/tree-standard/store/department-children/standard-department-children-definition';
 import { standardLocationsDefinition } from './routes/tree-standard/store/locations/standard-locations-definition';
 import { standardTopDefinition } from './routes/tree-standard/store/top/standard-top-definition.const';
-import { TreeStandardState } from './routes/tree-standard/store/tree-standard-state.interface';
+import { TreeStandardState2 } from './routes/tree-standard/store/tree-standard-state.interface';
 
 // This ensure we have one key per SharedState property
-const sharedReducersStandard = castTo<ActionReducerMap<TreeStandardState>>({
+const sharedReducersStandard: ActionReducerMap<TreeStandardState2> = {
   currentLocation: currentLocationStandardReducer,
-});
+};
 
-const sharedReducersNoRefresh = castTo<ActionReducerMap<TreeStandardState>>({
+const sharedReducersNoRefresh: ActionReducerMap<TreeStandardState2> = {
   currentLocation: currentLocationNoRefreshReducer,
-});
-const sharedReducersNoDirty = castTo<ActionReducerMap<TreeStandardState>>({
+};
+const sharedReducersNoDirty: ActionReducerMap<TreeStandardState2> = {
   currentLocation: currentLocationNoDirtyReducer,
-});
-const sharedReducersNoRemove = castTo<ActionReducerMap<TreeStandardState>>({
+};
+const sharedReducersNoRemove: ActionReducerMap<TreeStandardState2> = {
   currentLocation: currentLocationNoRemoveReducer,
-});
+};
 
 export const appRoutes: Routes = [
   {

--- a/apps/demo/src/app/routes/tree-no-dirty/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department/department.selector.ts
@@ -1,8 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeNoDirtyState } from '../tree-no-dirty.selectors';
@@ -24,7 +22,7 @@ export const selectDepartmentsChildren = createSmartSelector(
       parentFeature: 'tree-no-dirty',
       parentEntity: 'departments',
       parentField: 'children',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(selectDepartmentChildren),
+      childSelector: selectDepartmentChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';
@@ -26,9 +24,7 @@ export const selectLocationsDepartments = createSmartSelector(
       parentFeature: 'tree-no-dirty',
       parentEntity: 'locations',
       parentField: 'departments',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(
-        selectDepartmentsChildren,
-      ),
+      childSelector: selectDepartmentsChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-no-dirty/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/top/top.selector.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated.
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';
@@ -24,7 +22,7 @@ export const selectTopLocations = createSmartSelector(selectTopEntities, [
     parentField: 'locations',
     parentFeature: 'tree-no-dirty',
     parentEntity: 'top',
-    childSelector: castTo<SmartNgRXRowBaseSelector>(selectLocationsDepartments),
+    childSelector: selectLocationsDepartments,
   },
 ]);
 

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department/department.selector.ts
@@ -1,8 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeNoRefreshState } from '../tree-no-refresh.selectors';
@@ -24,7 +22,7 @@ export const selectDepartmentsChildren = createSmartSelector(
       parentFeature: 'tree-no-refresh',
       parentEntity: 'departments',
       parentField: 'children',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(selectDepartmentChildren),
+      childSelector: selectDepartmentChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';
@@ -26,9 +24,7 @@ export const selectLocationsDepartments = createSmartSelector(
       parentFeature: 'tree-no-refresh',
       parentEntity: 'locations',
       parentField: 'departments',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(
-        selectDepartmentsChildren,
-      ),
+      childSelector: selectDepartmentsChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-no-refresh/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/top/top.selector.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated.
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';
@@ -24,7 +22,7 @@ export const selectTopLocations = createSmartSelector(selectTopEntities, [
     parentField: 'locations',
     parentFeature: 'tree-no-refresh',
     parentEntity: 'top',
-    childSelector: castTo<SmartNgRXRowBaseSelector>(selectLocationsDepartments),
+    childSelector: selectLocationsDepartments,
   },
 ]);
 

--- a/apps/demo/src/app/routes/tree-no-remove/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department/department.selector.ts
@@ -1,8 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeNoRemoveState } from '../tree-no-remove.selectors';
@@ -24,7 +22,7 @@ export const selectDepartmentsChildren = createSmartSelector(
       parentFeature: 'tree-no-remove',
       parentEntity: 'departments',
       parentField: 'children',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(selectDepartmentChildren),
+      childSelector: selectDepartmentChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';
@@ -26,9 +24,7 @@ export const selectLocationsDepartments = createSmartSelector(
       parentFeature: 'tree-no-remove',
       parentEntity: 'locations',
       parentField: 'departments',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(
-        selectDepartmentsChildren,
-      ),
+      childSelector: selectDepartmentsChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-no-remove/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/top/top.selector.ts
@@ -1,8 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';
@@ -22,7 +20,7 @@ export const selectTopLocations = createSmartSelector(selectTopEntities, [
     parentField: 'locations',
     parentFeature: 'tree-no-remove',
     parentEntity: 'top',
-    childSelector: castTo<SmartNgRXRowBaseSelector>(selectLocationsDepartments),
+    childSelector: selectLocationsDepartments,
   },
 ]);
 

--- a/apps/demo/src/app/routes/tree-standard/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department/department.selector.ts
@@ -1,8 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeStandardState } from '../tree-standard-state.selectors';
@@ -24,7 +22,7 @@ export const selectDepartmentsChildren = createSmartSelector(
       parentFeature: 'tree-standard',
       parentEntity: 'departments',
       parentField: 'children',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(selectDepartmentChildren),
+      childSelector: selectDepartmentChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';
@@ -26,9 +24,7 @@ export const selectLocationsDepartments = createSmartSelector(
       parentField: 'departments',
       parentFeature: 'tree-standard',
       parentEntity: 'locations',
-      childSelector: castTo<SmartNgRXRowBaseSelector>(
-        selectDepartmentsChildren,
-      ),
+      childSelector: selectDepartmentsChildren,
     },
   ],
 );

--- a/apps/demo/src/app/routes/tree-standard/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/top/top.selector.ts
@@ -2,9 +2,7 @@
 // intentionally duplicated.
 import { createSelector } from '@ngrx/store';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
-import { SmartNgRXRowBaseSelector } from '@smart/smart-ngrx/types/smart-ngrx-row-base-selector.type';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';
@@ -24,7 +22,7 @@ export const selectTopLocations = createSmartSelector(selectTopEntities, [
     parentField: 'locations',
     parentFeature: 'tree-standard',
     parentEntity: 'top',
-    childSelector: castTo<SmartNgRXRowBaseSelector>(selectLocationsDepartments),
+    childSelector: selectLocationsDepartments,
   },
 ]);
 

--- a/apps/demo/src/app/shared/components/tree/common-source-node.interface.ts
+++ b/apps/demo/src/app/shared/components/tree/common-source-node.interface.ts
@@ -1,8 +1,9 @@
 import { RowProxyDelete } from '@smart/smart-ngrx/row-proxy/row-proxy-delete.interface';
+import { SmartArray } from '@smart/smart-ngrx/selector/smart-array.interface';
 import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
 export interface CommonSourceNode extends SmartNgRXRowBase, RowProxyDelete {
   id: string;
   type?: string;
   name: string;
-  children: CommonSourceNode[] | string[];
+  children: (CommonSourceNode | string)[] & SmartArray;
 }

--- a/apps/demo/src/app/shared/components/tree/common-source-node.interface.ts
+++ b/apps/demo/src/app/shared/components/tree/common-source-node.interface.ts
@@ -1,6 +1,6 @@
+import { RowProxyDelete } from '@smart/smart-ngrx/row-proxy/row-proxy-delete.interface';
 import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
-
-export interface CommonSourceNode extends SmartNgRXRowBase {
+export interface CommonSourceNode extends SmartNgRXRowBase, RowProxyDelete {
   id: string;
   type?: string;
   name: string;

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
@@ -377,4 +377,28 @@ describe('TreeComponentService', () => {
       expect(removeChildSpy).not.toHaveBeenCalled();
     });
   });
+  describe('when deleteNode is called and the node has a delete method', () => {
+    it('should call the delete method', () => {
+      const deleteSpy = jest.fn();
+      service.deleteNode({
+        node: { delete: deleteSpy, id: '1', name: '', children: [] },
+        name: '',
+        level: 1,
+        hasChildren: true,
+      });
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe('when deleteNode is called and the node does not have a delete method', () => {
+    it('should call the delete method', () => {
+      const deleteSpy = jest.fn();
+      service.deleteNode({
+        node: { id: '1', name: '', children: [] },
+        name: '',
+        level: 1,
+        hasChildren: true,
+      });
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
@@ -377,28 +377,4 @@ describe('TreeComponentService', () => {
       expect(removeChildSpy).not.toHaveBeenCalled();
     });
   });
-  describe('when deleteNode is called and the node has a delete method', () => {
-    it('should call the delete method', () => {
-      const deleteSpy = jest.fn();
-      service.deleteNode({
-        node: { delete: deleteSpy, id: '1', name: '', children: [] },
-        name: '',
-        level: 1,
-        hasChildren: true,
-      });
-      expect(deleteSpy).toHaveBeenCalledTimes(1);
-    });
-  });
-  describe('when deleteNode is called and the node does not have a delete method', () => {
-    it('should call the delete method', () => {
-      const deleteSpy = jest.fn();
-      service.deleteNode({
-        node: { id: '1', name: '', children: [] },
-        name: '',
-        level: 1,
-        hasChildren: true,
-      });
-      expect(deleteSpy).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
@@ -247,6 +247,8 @@ describe('TreeComponentService', () => {
       }) as unknown as typeof componentInstance.location;
       jest
         .spyOn(
+          // isExpanded is a private method, we cast it here to make it public
+          // so we can spy on it
           castTo<{
             isExpanded(node: { node: { id: string }; level: number }): boolean;
           }>(service),

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.ts
@@ -3,10 +3,8 @@ import { Injectable } from '@angular/core';
 import { assert } from '@smart/smart-ngrx/common/assert.function';
 import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { forNext } from '@smart/smart-ngrx/common/for-next.function';
-import { RowProxy } from '@smart/smart-ngrx/row-proxy/row-proxy.class';
 import { ArrayProxy } from '@smart/smart-ngrx/selector/array-proxy.class';
 
-import { Department } from '../../department/department.interface';
 import { DepartmentChild } from '../../department-children/department-child.interface';
 import { CommonSourceNode } from './common-source-node.interface';
 import type { TreeComponent } from './tree.component';
@@ -91,13 +89,16 @@ export class TreeComponentService {
       this.toggleExpand(parent);
     }
 
-    castTo<ArrayProxy<Department, DepartmentChild>>(
-      parent.node.children,
-    ).addToStore(row, parent.node);
+    castTo<ArrayProxy>(parent.node.children).addToStore(row, parent.node);
   }
 
   deleteNode(node: TreeNode): void {
-    castTo<RowProxy>(node.node).delete();
+    // because delete is an optional method,
+    // we need to check if it exists before calling it.
+    // if we don't make it optional, we will be
+    // forced to implement it everywhere we need
+    // a default row.
+    node.node.delete?.();
   }
 
   cancelEdit(node: TreeNode): void {
@@ -111,9 +112,10 @@ export class TreeComponentService {
   }
 
   removeChild(row: TreeNode, parent: TreeNode): void {
-    castTo<ArrayProxy<Department, DepartmentChild>>(
-      parent.node.children,
-    ).removeFromStore(row.node, parent.node);
+    castTo<ArrayProxy>(parent.node.children).removeFromStore(
+      row.node,
+      parent.node,
+    );
   }
 
   private isExpanded(node: TreeNode): boolean {

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { assert } from '@smart/smart-ngrx/common/assert.function';
 import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { forNext } from '@smart/smart-ngrx/common/for-next.function';
-import { ArrayProxy } from '@smart/smart-ngrx/selector/array-proxy.class';
+import { SmartArray } from '@smart/smart-ngrx/selector/smart-array.interface';
 
 import { DepartmentChild } from '../../department-children/department-child.interface';
 import { CommonSourceNode } from './common-source-node.interface';
@@ -46,7 +46,7 @@ export class TreeComponentService {
   }
 
   transform(
-    children: (CommonSourceNode | string)[],
+    children: (CommonSourceNode | string)[] & SmartArray,
     level: number,
     startRange: number,
     endRange: number,
@@ -55,7 +55,7 @@ export class TreeComponentService {
     if (children.length === 0) {
       return [];
     }
-    forNext(castTo<{ rawArray: string[] }>(children).rawArray, (c, i) => {
+    forNext(children.rawArray!, (c, i) => {
       let node: CommonSourceNode | string = c;
       if (startRange <= result.length && result.length <= endRange) {
         node = children[i];
@@ -89,7 +89,7 @@ export class TreeComponentService {
       this.toggleExpand(parent);
     }
 
-    castTo<ArrayProxy>(parent.node.children).addToStore(row, parent.node);
+    parent.node.children.addToStore!(row, parent.node);
   }
 
   deleteNode(node: TreeNode): void {
@@ -112,10 +112,7 @@ export class TreeComponentService {
   }
 
   removeChild(row: TreeNode, parent: TreeNode): void {
-    castTo<ArrayProxy>(parent.node.children).removeFromStore(
-      row.node,
-      parent.node,
-    );
+    parent.node.children.removeFromStore!(row.node, parent.node);
   }
 
   private isExpanded(node: TreeNode): boolean {

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { assert } from '@smart/smart-ngrx/common/assert.function';
 import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { forNext } from '@smart/smart-ngrx/common/for-next.function';
-import { CustomProxy } from '@smart/smart-ngrx/row-proxy/custom-proxy.class';
+import { RowProxy } from '@smart/smart-ngrx/row-proxy/row-proxy.class';
 import { ArrayProxy } from '@smart/smart-ngrx/selector/array-proxy.class';
 
 import { Department } from '../../department/department.interface';
@@ -97,7 +97,7 @@ export class TreeComponentService {
   }
 
   deleteNode(node: TreeNode): void {
-    castTo<CustomProxy>(node.node).delete();
+    castTo<RowProxy>(node.node).delete();
   }
 
   cancelEdit(node: TreeNode): void {

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 
 import { assert } from '@smart/smart-ngrx/common/assert.function';
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { forNext } from '@smart/smart-ngrx/common/for-next.function';
 import { SmartArray } from '@smart/smart-ngrx/selector/smart-array.interface';
 
@@ -73,7 +72,7 @@ export class TreeComponentService {
       result.push(r as TreeNode);
       if (this.isExpanded(r as TreeNode)) {
         const childNodes = this.transform(
-          castTo<CommonSourceNode>(children[i]).children,
+          (children[i] as CommonSourceNode).children,
           level + 1,
           startRange - result.length,
           endRange - result.length,
@@ -94,11 +93,9 @@ export class TreeComponentService {
 
   deleteNode(node: TreeNode): void {
     // because delete is an optional method,
-    // we need to check if it exists before calling it.
-    // if we don't make it optional, we will be
-    // forced to implement it everywhere we need
-    // a default row.
-    node.node.delete?.();
+    // but it actually exist by definition,
+    // we can safely assert that it exist.
+    node.node.delete!();
   }
 
   cancelEdit(node: TreeNode): void {

--- a/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
+++ b/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
@@ -1,14 +1,12 @@
 import { inject, Injectable } from '@angular/core';
 import { forkJoin, map, Observable, of } from 'rxjs';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
 import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
 
 import { DocsService } from '../docs/docs.service';
 import { FoldersService } from '../folders/folders.service';
 import { ListsService } from '../lists/lists.service';
 import { SprintFoldersService } from '../sprint-folders/sprint-folders.service';
-import { CommonService } from './common-service.class';
 import { DepartmentChild } from './department-child.interface';
 import { filterIds } from './filter-ids.function';
 import { loadByIdsForType } from './load-by-ids-for-type.function';
@@ -38,18 +36,10 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
 
     const docStream = loadByIdsForType(this.doc, docIds, this.docs, 'did');
 
-    const folderStream = loadByIdsForType(
-      castTo<CommonService>(this.folder),
-      folderIds,
-      this.folders,
-    );
-    const listStream = loadByIdsForType(
-      castTo<CommonService>(this.list),
-      listIds,
-      this.lists,
-    );
+    const folderStream = loadByIdsForType(this.folder, folderIds, this.folders);
+    const listStream = loadByIdsForType(this.list, listIds, this.lists);
     const sprintFolderStream = loadByIdsForType(
-      castTo<CommonService>(this.sprintFolder),
+      this.sprintFolder,
       sprintFolderIds,
       this.sprintFolders,
     );

--- a/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.spec.ts
+++ b/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.spec.ts
@@ -25,15 +25,11 @@ describe('loadByIdsForType', () => {
     testScheduler.run(({ expectObservable }) => {
       const mockService = {
         loadByIds,
-      };
+      } as CommonService;
       const ids = ['1'];
       const type = 'department';
 
-      const result = loadByIdsForType(
-        castTo<CommonService>(mockService),
-        ids,
-        type,
-      );
+      const result = loadByIdsForType(mockService, ids, type);
 
       const expectedOutput: DepartmentChild[] = [
         { id: 'department:1', name: 'Dept1', children: [] },
@@ -45,21 +41,17 @@ describe('loadByIdsForType', () => {
 
   it('should return an empty array on timeout', () => {
     testScheduler.run(({ expectObservable }) => {
-      const mockService = {
+      const mockService = castTo<CommonService>({
         loadByIds: (ids: string[]) =>
           timer(1500).pipe(
             map(() => ids),
             map((id) => ({ id, name: 'Dept' + id, children: [] })),
           ),
-      };
+      });
       const ids = ['1'];
       const type = 'department';
 
-      const result = loadByIdsForType(
-        castTo<CommonService>(mockService),
-        ids,
-        type,
-      );
+      const result = loadByIdsForType(mockService, ids, type);
 
       expectObservable(result).toBe('1000ms (a|)', { a: [] });
     });

--- a/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.ts
+++ b/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.ts
@@ -14,7 +14,7 @@ export function loadByIdsForType(
   return service.loadByIds(ids).pipe(
     map((items) =>
       items.map((item) => {
-        // convert the item to a record so we can access the idField
+        // convert the item to a record
         const itemRecord = castTo<Record<string, string>>(item);
         return {
           id: `${type}:${itemRecord[idField]}`,

--- a/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.ts
+++ b/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.ts
@@ -1,7 +1,5 @@
 import { catchError, map, Observable, of, timeout } from 'rxjs';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
-
 import { CommonService } from './common-service.class';
 import { DepartmentChild } from './department-child.interface';
 
@@ -14,10 +12,9 @@ export function loadByIdsForType(
   return service.loadByIds(ids).pipe(
     map((items) =>
       items.map((item) => {
-        // convert the item to a record
-        const itemRecord = castTo<Record<string, string>>(item);
+        const fieldValue = item[idField as keyof DepartmentChild] as string;
         return {
-          id: `${type}:${itemRecord[idField]}`,
+          id: `${type}:${fieldValue}`,
           name: item.name,
           children: [],
         } as DepartmentChild;

--- a/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.ts
+++ b/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.ts
@@ -14,6 +14,7 @@ export function loadByIdsForType(
   return service.loadByIds(ids).pipe(
     map((items) =>
       items.map((item) => {
+        // convert the item to a record so we can access the idField
         const itemRecord = castTo<Record<string, string>>(item);
         return {
           id: `${type}:${itemRecord[idField]}`,

--- a/apps/demo/src/app/shared/department-children/update-id-function.ts
+++ b/apps/demo/src/app/shared/department-children/update-id-function.ts
@@ -9,10 +9,11 @@ export function updateId(
   idName = 'id',
 ): DepartmentChild[] {
   return rows.map((row) => {
+    // convert the row to a record so we can access the idName
     const itemRecord = castTo<Record<string, string>>(row);
-    return castTo<DepartmentChild>({
+    return {
       ...row,
       id: `${type}:${itemRecord[idName]}`,
-    });
+    };
   });
 }

--- a/apps/demo/src/app/shared/department/department-effects.service.ts
+++ b/apps/demo/src/app/shared/department/department-effects.service.ts
@@ -4,7 +4,6 @@ import { map, Observable } from 'rxjs';
 
 import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
 
-import { addIsDirty } from '../functions/add-is-dirty.function';
 import { childrenTransform } from './children-transform.function';
 import { Department } from './department.interface';
 
@@ -27,17 +26,13 @@ export class DepartmentEffectsService extends EffectService<Department> {
         id: newRow.id,
         name: newRow.name,
       })
-      .pipe(
-        map((departments) => addIsDirty(departments) as Department[]),
-        map(childrenTransform),
-      );
+      .pipe(map(childrenTransform));
   }
 
   override add(row: Department): Observable<Department[]> {
-    return this.http.post<Department[]>(this.apiDepartments + '/add', row).pipe(
-      map((departments) => addIsDirty(departments) as Department[]),
-      map(childrenTransform),
-    );
+    return this.http
+      .post<Department[]>(this.apiDepartments + '/add', row)
+      .pipe(map(childrenTransform));
   }
 
   override delete(id: string): Observable<void> {

--- a/apps/documentation/src/app/demo-walkthrough/deleting-rows/index.md
+++ b/apps/documentation/src/app/demo-walkthrough/deleting-rows/index.md
@@ -4,4 +4,4 @@ Last, of course, is the ability to delete rows. Delete is implemented for Depart
 
 That's all you have to do to delete a node. All the real work is handled by SmartNgRX.
 
-`RowProxy` is a class that is part of SmartNgRX. If you use SmartNgRX, the row you are working with is a `RowProxy` object. You may need to cast your row to a `RowProxy`, as we have, to access the `delete` method.
+`RowProxy` is a class that is part of SmartNgRX. If you use SmartNgRX, the row you are working with is a `RowProxy` object. You can directly access the `delete()` method on the `RowProxy` object without casting.

--- a/apps/documentation/src/app/demo-walkthrough/deleting-rows/index.md
+++ b/apps/documentation/src/app/demo-walkthrough/deleting-rows/index.md
@@ -4,4 +4,4 @@ Last, of course, is the ability to delete rows. Delete is implemented for Depart
 
 That's all you have to do to delete a node. All the real work is handled by SmartNgRX.
 
-`CustomProxy` is a class that is part of SmartNgRX. If you use SmartNgRX, the row you are working with is a `CustomProxy` object. You may need to cast your row to a `CustomProxy`, as we have, to access the `delete` method.
+`RowProxy` is a class that is part of SmartNgRX. If you use SmartNgRX, the row you are working with is a `RowProxy` object. You may need to cast your row to a `RowProxy`, as we have, to access the `delete` method.

--- a/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
+++ b/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
@@ -10,6 +10,6 @@ deleteNode(node: TreeNode): void {
 }
 ```
 
-Note: node.node is typed as `RowProxyDelete` which defines the optional delete method. Because the delete method will, by definition, be available we can safely use the non-null assertion operator `!` to call it.
+Note: node.node is typed as `RowProxyDelete`, which defines the optional delete method. Because the delete method will, by definition, be available we can safely use the non-null assertion operator `!` to call it.
 
 Everything else happens for you under the covers.

--- a/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
+++ b/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
@@ -1,6 +1,6 @@
 # Deleting a Row
 
-Every row that is returned by SmartNgRX is wrapped in the RowProxy class which provides access to a delete() method. Calling delete() on a row will optimistically remove the row from the store, including the child arrays in every parent that references it. Then the delete method in your Effect Service will get called. If the delete method fails, the delete will be rolled back.
+Every row that is returned by SmartNgRX is wrapped in the RowProxy class which provides access to a `delete()` method. Calling `delete()` on a row will optimistically remove the row from the store, including the child arrays in every parent that references it. Then the `delete()` method in your Effect Service will get called. If the `delete()` method fails, the delete will be rolled back.
 
 Sample code from the demo app:
 

--- a/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
+++ b/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
@@ -6,8 +6,10 @@ Sample code from the demo app:
 
 ```typescript
 deleteNode(node: TreeNode): void {
-  castTo<RowProxy>(node.node).delete();
+  node.node.delete!();
 }
 ```
+
+Note: node.node is typed as `RowProxyDelete` which defines the optional delete method. Because the delete method will, by definition, be available we can safely use the non-null assertion operator `!` to call it.
 
 Everything else happens for you under the covers.

--- a/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
+++ b/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
@@ -10,6 +10,6 @@ deleteNode(node: TreeNode): void {
 }
 ```
 
-Note: node.node is typed as `RowProxyDelete`, which defines the optional delete method. Because the delete method will, by definition, be available we can safely use the non-null assertion operator `!` to call it.
+Note: node.node is typed as `RowProxyDelete`, which defines the optional delete method. Because the delete method will, by definition, be available, we can safely use the non-null assertion operator `!` to call it.
 
 Everything else happens for you under the covers.

--- a/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
+++ b/apps/documentation/src/app/using-smart-ng-rx/crud-support/deleting/index.md
@@ -1,12 +1,12 @@
 # Deleting a Row
 
-Every row that is returned by SmartNgRX is wrapped in the CustomProxy class which provides access to a delete() method. Calling delete() on a row will optimistically remove the row from the store, including the child arrays in every parent that references it. Then the delete method in your Effect Service will get called. If the delete method fails, the delete will be rolled back.
+Every row that is returned by SmartNgRX is wrapped in the RowProxy class which provides access to a delete() method. Calling delete() on a row will optimistically remove the row from the store, including the child arrays in every parent that references it. Then the delete method in your Effect Service will get called. If the delete method fails, the delete will be rolled back.
 
 Sample code from the demo app:
 
 ```typescript
 deleteNode(node: TreeNode): void {
-  castTo<CustomProxy>(node.node).delete();
+  castTo<RowProxy>(node.node).delete();
 }
 ```
 

--- a/libs/smart-ngrx/src/registrations/child-definition.registry.ts
+++ b/libs/smart-ngrx/src/registrations/child-definition.registry.ts
@@ -2,6 +2,7 @@ import { assert } from '../common/assert.function';
 import { castTo } from '../common/cast-to.function';
 import { psi } from '../common/theta.const';
 import { ChildDefinition } from '../types/child-definition.interface';
+import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
 interface ChildField {
   childField: string;
@@ -19,10 +20,10 @@ class ChildDefinitionRegistry {
    * @param entity the entity the definition is for
    * @param childDefinition the childDefinition to register
    */
-  registerChildDefinition<P>(
+  registerChildDefinition<P, T extends SmartNgRXRowBase>(
     feature: string,
     entity: string,
-    childDefinition: ChildDefinition<P>,
+    childDefinition: ChildDefinition<P, string, string, string, string, T>,
   ): void {
     const existingEntries =
       this.childDefinitionMap.get(`${feature}${psi}${entity}`) ?? [];

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-delete.interface.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-delete.interface.ts
@@ -1,0 +1,6 @@
+export interface RowProxyDelete {
+  /**
+   * This deletes the row from the store and the server
+   */
+  delete?(): void;
+}

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.spec.ts
@@ -1,7 +1,7 @@
 import { ActionService } from '../actions/action.service';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { CustomProxy } from './custom-proxy.class';
-import { customProxyGet } from './custom-proxy-get.function';
+import { RowProxy } from './row-proxy.class';
+import { rowProxyGet } from './row-proxy-get.function';
 
 describe('customProxyGet()', () => {
   const target = {
@@ -22,7 +22,7 @@ describe('customProxyGet()', () => {
       b: 'c',
     },
     row: {},
-  } as unknown as CustomProxy<object>;
+  } as unknown as RowProxy<object>;
   const service = {
     loadByIdsSuccess: () => {
       /*noop*/
@@ -46,7 +46,7 @@ describe('customProxyGet()', () => {
       // Arrange
       const prop = 'toJSON';
       // Act
-      const result = customProxyGet(target, prop, service) as () => void;
+      const result = rowProxyGet(target, prop, service) as () => void;
       result();
       // Assert
       expect(getJsonSpy).toHaveBeenCalled();
@@ -58,7 +58,7 @@ describe('customProxyGet()', () => {
       // Arrange
       const prop = 'isEditing';
       // Act
-      customProxyGet(target, prop, service);
+      rowProxyGet(target, prop, service);
       // Assert
       expect(loadByIdsSuccessSpy).toHaveBeenCalled();
     });
@@ -66,7 +66,7 @@ describe('customProxyGet()', () => {
   describe('when prop is "getRealRow"', () => {
     it('should return a function that calls target.getRealRow()', () => {
       const prop = 'getRealRow';
-      const result = customProxyGet(target, prop, service) as () => void;
+      const result = rowProxyGet(target, prop, service) as () => void;
       result();
       expect(getRealRowSpy).toHaveBeenCalled();
       expect(getJsonSpy).not.toHaveBeenCalled();
@@ -75,7 +75,7 @@ describe('customProxyGet()', () => {
   describe('when prop is "delete"', () => {
     it('should return a function that calls target.delete()', () => {
       const prop = 'delete';
-      const result = customProxyGet(target, prop, service) as () => void;
+      const result = rowProxyGet(target, prop, service) as () => void;
       result();
       expect(deleteSpy).toHaveBeenCalled();
       expect(getJsonSpy).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe('customProxyGet()', () => {
     it('should return the value from changes', () => {
       const prop = 'a';
       // Act
-      const result = customProxyGet(target, prop, service) as () => void;
+      const result = rowProxyGet(target, prop, service) as () => void;
       expect(result).toBe('a');
     });
   });
@@ -93,7 +93,7 @@ describe('customProxyGet()', () => {
     it('should return the value from record', () => {
       const prop = 'b';
       // Act
-      const result = customProxyGet(target, prop, service) as () => void;
+      const result = rowProxyGet(target, prop, service) as () => void;
       expect(result).toBe('c');
     });
   });

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.ts
@@ -1,20 +1,20 @@
 import { ActionService } from '../actions/action.service';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { CustomProxy } from './custom-proxy.class';
+import { RowProxy } from './row-proxy.class';
 
 /**
- * This provides the get method of the Proxy in CustomProxy
+ * This provides the get method of the Proxy in RowProxy
  *
- * @param target the CustomProxy the Proxy targets
+ * @param target the RowProxy the Proxy targets
  * @param prop the property the proxy needs to retrieve
  * @param service the service that handles the actions for the row
  * @returns the value of the property
  */
-export function customProxyGet<
+export function rowProxyGet<
   T extends SmartNgRXRowBase,
   P extends SmartNgRXRowBase,
 >(
-  target: CustomProxy<T, P>,
+  target: RowProxy<T, P>,
   prop: string | symbol,
   service: ActionService<T>,
 ): unknown {

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.spec.ts
@@ -1,10 +1,10 @@
 import { ActionService } from '../actions/action.service';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { CustomProxy } from './custom-proxy.class';
-import { customProxySet } from './custom-proxy-set.function';
+import { RowProxy } from './row-proxy.class';
+import { rowProxySet } from './row-proxy-set.function';
 
 describe('customProxySet', () => {
-  let target: CustomProxy | undefined;
+  let target: RowProxy | undefined;
   let services: {
     service: ActionService<SmartNgRXRowBase>;
     parentService: ActionService<SmartNgRXRowBase>;
@@ -19,7 +19,7 @@ describe('customProxySet', () => {
         b: 'c',
       },
       getRealRow: () => ({}) as SmartNgRXRowBase,
-    } as unknown as CustomProxy;
+    } as unknown as RowProxy;
     services = {
       service: {
         add: () => {
@@ -45,7 +45,7 @@ describe('customProxySet', () => {
   describe('when prop is not in target.record', () => {
     it('should return false', () => {
       expect(
-        customProxySet(target!, 'c', 'd', {
+        rowProxySet(target!, 'c', 'd', {
           service: {} as ActionService<SmartNgRXRowBase>,
           parentService: {} as ActionService<SmartNgRXRowBase>,
         }),
@@ -59,13 +59,13 @@ describe('customProxySet', () => {
           ({ parentId: 1 }) as unknown as SmartNgRXRowBase;
       });
       it('should add the new row', () => {
-        customProxySet(target!, 'a', 'd', services);
+        rowProxySet(target!, 'a', 'd', services);
         expect(serviceAddSpy).toHaveBeenCalled();
       });
     });
     describe('when target does not have a parentId', () => {
       it('should update the row', () => {
-        customProxySet(target!, 'a', 'd', services);
+        rowProxySet(target!, 'a', 'd', services);
         expect(serviceAddSpy).not.toHaveBeenCalled();
         expect(serviceUpdateSpy).toHaveBeenCalled();
       });

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.ts
@@ -1,12 +1,12 @@
 import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { CustomProxy } from './custom-proxy.class';
+import { RowProxy } from './row-proxy.class';
 
 /**
- * This provides the set method of the Proxy in CustomProxy
+ * This provides the set method of the Proxy in RowProxy
  *
- * @param target the CustomProxy the Proxy targets
+ * @param target the RowProxy the Proxy targets
  * @param prop the property the proxy needs to set
  * @param value the value to set the property to
  * @param services the services associated with the row and parent entity
@@ -14,11 +14,11 @@ import { CustomProxy } from './custom-proxy.class';
  * @param services.parentService the service associated with the parent entity
  * @returns true if the property was set, false otherwise
  */
-export function customProxySet<
+export function rowProxySet<
   T extends SmartNgRXRowBase,
   P extends SmartNgRXRowBase,
 >(
-  target: CustomProxy<T, P>,
+  target: RowProxy<T, P>,
   prop: string | symbol,
   value: unknown,
   services: { service: ActionService<T>; parentService: ActionService<P> },

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.spec.ts
@@ -1,7 +1,7 @@
 import { ActionService } from '../actions/action.service';
 import { ArrayProxy } from '../selector/array-proxy.class';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { CustomProxy } from './custom-proxy.class';
+import { RowProxy } from './row-proxy.class';
 
 interface CRow extends SmartNgRXRowBase {
   id: string;
@@ -14,8 +14,8 @@ interface TRow extends SmartNgRXRowBase {
   children: ArrayProxy<object, CRow>;
 }
 
-describe('CustomProxy', () => {
-  let customProxy: CustomProxy<TRow, CRow> | undefined;
+describe('RowProxy', () => {
+  let customProxy: RowProxy<TRow, CRow> | undefined;
   beforeEach(() => {
     const row = {
       id: '1',
@@ -23,7 +23,7 @@ describe('CustomProxy', () => {
       children: ['child1a', 'child2a'] as unknown as ArrayProxy<object, CRow>,
     };
     row.children.rawArray = ['child1', 'child2'];
-    customProxy = new CustomProxy<TRow, CRow>(
+    customProxy = new RowProxy<TRow, CRow>(
       row as unknown as TRow,
       {} as ActionService<TRow>,
       {} as ActionService<CRow>,

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
@@ -2,6 +2,7 @@ import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
 import { forNext } from '../common/for-next.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
+import { RowProxyDelete } from './row-proxy-delete.interface';
 import { rowProxyGet } from './row-proxy-get.function';
 import { rowProxySet } from './row-proxy-set.function';
 
@@ -20,7 +21,8 @@ import { rowProxySet } from './row-proxy-set.function';
 export class RowProxy<
   T extends SmartNgRXRowBase = SmartNgRXRowBase,
   P extends SmartNgRXRowBase = SmartNgRXRowBase,
-> {
+> implements RowProxyDelete
+{
   changes = {} as Record<string | symbol, unknown>;
   record: Record<string | symbol, unknown> = {};
 

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
@@ -2,22 +2,22 @@ import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
 import { forNext } from '../common/for-next.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { customProxyGet } from './custom-proxy-get.function';
-import { customProxySet } from './custom-proxy-set.function';
+import { rowProxyGet } from './row-proxy-get.function';
+import { rowProxySet } from './row-proxy-set.function';
 
 /**
- * CustomProxy wraps the row so we can intercept changes to it
+ * RowProxy wraps the row so we can intercept changes to it
  * and fire off the appropriate actions to update the store and
  * the server.
  *
  * Since proxying the row directly will cause the setter to throw
  * an error when the NgRX rules are turned on that disallow mutating
  * the row directly, we need to wrap the row in our own class that
- * uses the Proxy class to handle the updates. By casting the CustomProxy
+ * uses the Proxy class to handle the updates. By casting the RowProxy
  * to type T (above) the rest of our code still believes it is working
  * with the original row.
  */
-export class CustomProxy<
+export class RowProxy<
   T extends SmartNgRXRowBase = SmartNgRXRowBase,
   P extends SmartNgRXRowBase = SmartNgRXRowBase,
 > {
@@ -25,7 +25,7 @@ export class CustomProxy<
   record: Record<string | symbol, unknown> = {};
 
   /**
-   * This is the constructor for the CustomProxy class.
+   * This is the constructor for the RowProxy class.
    *
    * @param row The row to create the custom proxy for
    * @param service The service that will handle updating the row
@@ -39,9 +39,9 @@ export class CustomProxy<
   ) {
     this.record = castTo<Record<string | symbol, unknown>>(row);
     return new Proxy(this, {
-      get: (target, prop) => customProxyGet(target, prop, service),
+      get: (target, prop) => rowProxyGet(target, prop, service),
       set: (target, prop, value) =>
-        customProxySet(target, prop, value, { service, parentService }),
+        rowProxySet(target, prop, value, { service, parentService }),
     });
   }
 

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.function.ts
@@ -2,6 +2,7 @@ import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { RowProxy } from './row-proxy.class';
+import { RowProxyDelete } from './row-proxy-delete.interface';
 
 /**
  * Wraps a row in a proxy that will take care of editing the row
@@ -20,6 +21,10 @@ import { RowProxy } from './row-proxy.class';
 export function rowProxy<
   T extends SmartNgRXRowBase,
   P extends SmartNgRXRowBase,
->(row: T, service: ActionService<T>, parentService: ActionService<P>): T {
-  return castTo<T>(new RowProxy(row, service, parentService));
+>(
+  row: T,
+  service: ActionService<T>,
+  parentService: ActionService<P>,
+): RowProxyDelete & T {
+  return castTo<RowProxyDelete & T>(new RowProxy(row, service, parentService));
 }

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.function.ts
@@ -1,7 +1,7 @@
 import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
-import { CustomProxy } from './custom-proxy.class';
+import { RowProxy } from './row-proxy.class';
 
 /**
  * Wraps a row in a proxy that will take care of editing the row
@@ -21,5 +21,5 @@ export function rowProxy<
   T extends SmartNgRXRowBase,
   P extends SmartNgRXRowBase,
 >(row: T, service: ActionService<T>, parentService: ActionService<P>): T {
-  return castTo<T>(new CustomProxy(row, service, parentService));
+  return castTo<T>(new RowProxy(row, service, parentService));
 }

--- a/libs/smart-ngrx/src/selector/array-proxy-class.get.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy-class.get.function.spec.ts
@@ -1,4 +1,3 @@
-import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { ArrayProxy } from './array-proxy.class';
 import { arrayProxyClassGet } from './array-proxy-class.get.function';
 
@@ -7,7 +6,7 @@ describe('arrayProxyClassGet()', () => {
     getAtIndex(_: number): unknown {
       return {};
     },
-  } as ArrayProxy<object, SmartNgRXRowBase>;
+  } as ArrayProxy;
   let getAtIndexSpy: jest.SpyInstance;
   let reflectGetSpy: jest.SpyInstance;
   beforeEach(() => {

--- a/libs/smart-ngrx/src/selector/array-proxy-class.get.function.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy-class.get.function.ts
@@ -12,7 +12,7 @@ export function arrayProxyClassGet<
   P extends object,
   C extends SmartNgRXRowBase,
 >(target: ArrayProxy<P, C>, prop: string | symbol): unknown {
-  if (typeof prop === 'string' && !isNaN(+prop)) {
+  if (typeof prop === 'string' && !Number.isNaN(+prop)) {
     return target.getAtIndex(+prop);
   }
   return Reflect.get(target, prop as keyof ArrayProxy);

--- a/libs/smart-ngrx/src/selector/array-proxy-class.get.function.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy-class.get.function.ts
@@ -15,8 +15,5 @@ export function arrayProxyClassGet<
   if (typeof prop === 'string' && !isNaN(+prop)) {
     return target.getAtIndex(+prop);
   }
-  return Reflect.get(
-    target,
-    prop as keyof ArrayProxy<object, SmartNgRXRowBase>,
-  );
+  return Reflect.get(target, prop as keyof ArrayProxy);
 }

--- a/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
@@ -8,7 +8,7 @@ import {
   registerEntity,
   unregisterEntity,
 } from '../registrations/register-entity.function';
-import { CustomProxy } from '../row-proxy/custom-proxy.class';
+import { RowProxy } from '../row-proxy/row-proxy.class';
 import { createStore } from '../tests/functions/create-store.function';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { EntityAttributes } from '../types/entity-attributes.interface';
@@ -179,7 +179,7 @@ describe('ArrayProxy', () => {
     });
   });
   describe('createNewParentFromParent()', () => {
-    describe('when parent is not a CustomProxy', () => {
+    describe('when parent is not a RowProxy', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
         arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
@@ -208,7 +208,7 @@ describe('ArrayProxy', () => {
         });
       });
     });
-    describe('when parent is a CustomProxy', () => {
+    describe('when parent is a RowProxy', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
         arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
@@ -226,7 +226,7 @@ describe('ArrayProxy', () => {
           isEditing: false,
           isDirty: false,
         };
-        const parentProxy = new CustomProxy(
+        const parentProxy = new RowProxy(
           parent,
           {} as unknown as ActionService<typeof parent>,
           {} as unknown as ActionService<SmartNgRXRowBase>,

--- a/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
@@ -23,7 +23,7 @@ const childDefinition = {
 } as unknown as ChildDefinition<SmartNgRXRowBase>;
 
 describe('ArrayProxy', () => {
-  let arrayProxy: ArrayProxy<object, SmartNgRXRowBase> | undefined;
+  let arrayProxy: ArrayProxy | undefined;
   let originalArray: string[] = [];
   let getArrayItemSpy: jest.SpyInstance;
   function assertArrayProxy(ap: boolean): asserts ap {

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -6,6 +6,7 @@ import { isProxy } from '../common/is-proxy.const';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { RowProxy } from '../row-proxy/row-proxy.class';
+import { RowProxyDelete } from '../row-proxy/row-proxy-delete.interface';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { arrayProxyClassGet } from './array-proxy-class.get.function';
@@ -19,7 +20,10 @@ import { isArrayProxy } from './is-array-proxy.function';
  *
  * @see `createSmartSelector`
  */
-export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
+export class ArrayProxy<
+    P extends object = object,
+    C extends SmartNgRXRowBase = SmartNgRXRowBase,
+  >
   implements ArrayLike<C>, Iterable<C>
 {
   entityAdapter: EntityAdapter<C>;
@@ -71,7 +75,7 @@ export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
    * @yields The next item in the iteration.
    * @returns The next item in the iteration.
    */
-  *[Symbol.iterator](): Iterator<C> {
+  *[Symbol.iterator](): Iterator<C & RowProxyDelete> {
     const len = this.rawArray.length;
     for (let i = 0; i < len; i++) {
       yield this.getAtIndex(i);
@@ -107,15 +111,15 @@ export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
    * @returns what this would return if it were a real array.  Mostly for
    * unit testing.
    */
-  toJSON(): C[] {
-    const array: C[] = [];
+  toJSON(): (C & RowProxyDelete)[] {
+    const array: (C & RowProxyDelete)[] = [];
     for (let i = 0; i < this.length; i++) {
       array.push(this.getAtIndex(i));
     }
     return array;
   }
 
-  [n: number]: C;
+  [n: number]: C & RowProxyDelete;
   length = 0;
 
   /**
@@ -127,7 +131,7 @@ export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
    * @returns the item from the store or the default row if it is not in the
    * store yet.
    */
-  getAtIndex(index: number): C {
+  getAtIndex(index: number): C & RowProxyDelete {
     if (index >= 0 && index < this.rawArray.length) {
       const id = this.rawArray[index];
       return getArrayItem<C, P>(this.child, id, this.childDefinition);

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -5,7 +5,7 @@ import { castTo } from '../common/cast-to.function';
 import { isProxy } from '../common/is-proxy.const';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
-import { CustomProxy } from '../row-proxy/custom-proxy.class';
+import { RowProxy } from '../row-proxy/row-proxy.class';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { arrayProxyClassGet } from './array-proxy-class.get.function';
@@ -200,9 +200,9 @@ export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
    */
   private createNewParentFromParent(parent: P, isEditing: boolean): P {
     let newParent: P = { ...parent, isEditing };
-    // we aren't using the 2nd generic parameter of CustomProxy, so we just
+    // we aren't using the 2nd generic parameter of RowProxy, so we just
     // use the base type of SmartNgRXRowBase here.
-    const customProxy = castTo<CustomProxy<P>>(parent);
+    const customProxy = castTo<RowProxy<P>>(parent);
     if (customProxy.getRealRow !== undefined) {
       newParent = {
         ...customProxy.getRealRow(),

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -38,7 +38,14 @@ export class ArrayProxy<P extends object, C extends SmartNgRXRowBase>
   constructor(
     private childArray: ArrayProxy<P, C> | string[],
     private child: EntityState<C>,
-    private childDefinition: ChildDefinition<P>,
+    private childDefinition: ChildDefinition<
+      P,
+      string,
+      string,
+      string,
+      string,
+      C
+    >,
   ) {
     const { childFeature, childEntity } = this.childDefinition;
     this.childActionService = castTo<ActionService<C>>(

--- a/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
@@ -33,7 +33,7 @@ export function createInnerSmartSelector<
   C extends SmartNgRXRowBase,
 >(
   parentSelector: ParentSelector<P>,
-  childDefinition: ChildDefinition<P>,
+  childDefinition: ChildDefinition<P, string, string, string, string, C>,
 ): MemoizedSelector<object, EntityState<P>> {
   const {
     childFeature,
@@ -61,7 +61,7 @@ export function createInnerSmartSelector<
 
         const arrayProxy = new ArrayProxy<P, C>(
           childArray,
-          child as EntityState<C>,
+          child,
           childDefinition,
         );
         arrayProxy.init();

--- a/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
@@ -1,7 +1,9 @@
 import { EntityState } from '@ngrx/entity';
 import { MemoizedSelector } from '@ngrx/store';
 
+import { castTo } from '../common/cast-to.function';
 import { ChildDefinition } from '../types/child-definition.interface';
+import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { createInnerSmartSelector } from './create-inner-smart-selector.function';
 import { ParentSelector } from './parent-selector.type';
 
@@ -25,12 +27,18 @@ import { ParentSelector } from './parent-selector.type';
  * @see `ProxyChild`
  * @see `ParentSelector`
  */
-export function createSmartSelector<P extends object>(
+export function createSmartSelector<
+  P extends object,
+  T extends SmartNgRXRowBase,
+>(
   parentSelector: ParentSelector<P>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- easiest way to allow any string definition
-  children: ChildDefinition<P, any, any, any, any>[],
+  children: ChildDefinition<P, any, any, any, any, T>[],
 ): MemoizedSelector<object, EntityState<P>> {
   return children.reduce((p, child) => {
-    return createInnerSmartSelector(p, child as ChildDefinition<P>);
+    return createInnerSmartSelector(
+      p,
+      castTo<ChildDefinition<P, string, string, string, string, T>>(child),
+    );
   }, parentSelector);
 }

--- a/libs/smart-ngrx/src/selector/get-array-item.function.ts
+++ b/libs/smart-ngrx/src/selector/get-array-item.function.ts
@@ -22,7 +22,7 @@ export function getArrayItem<
 >(
   entityState: EntityState<T>,
   id: string,
-  childDefinition: ChildDefinition<P>,
+  childDefinition: ChildDefinition<P, string, string, string, string, T>,
 ): T {
   const { childFeature, childEntity } = childDefinition;
 
@@ -31,7 +31,7 @@ export function getArrayItem<
   return realOrMocked(
     entityState,
     id,
-    registry.defaultRow(id),
+    registry.defaultRow(id) as T,
     childDefinition,
-  ) as T;
+  );
 }

--- a/libs/smart-ngrx/src/selector/get-array-item.function.ts
+++ b/libs/smart-ngrx/src/selector/get-array-item.function.ts
@@ -1,6 +1,7 @@
 import { EntityState } from '@ngrx/entity';
 
 import { getEntityRegistry } from '../registrations/register-entity.function';
+import { RowProxyDelete } from '../row-proxy/row-proxy-delete.interface';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { ensureDataLoaded } from './ensure-data-loaded.function';
@@ -23,7 +24,7 @@ export function getArrayItem<
   entityState: EntityState<T>,
   id: string,
   childDefinition: ChildDefinition<P, string, string, string, string, T>,
-): T {
+): RowProxyDelete & T {
   const { childFeature, childEntity } = childDefinition;
 
   const registry = getEntityRegistry(childFeature, childEntity);

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
@@ -87,7 +87,7 @@ describe('realOrMocked', () => {
   it('returns the mocked value if real one is not available', () => {
     const r = realOrMocked(real, 'department2', defaultObject, childDefinition);
 
-    expect(r).toEqual({
+    expect(JSON.parse(JSON.stringify(r))).toEqual({
       id: 'department2',
       name: 'to be fetched',
       isDirty: false,

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
@@ -37,7 +37,14 @@ describe('realOrMocked', () => {
     childEntity: 'entity',
     parentFeature: 'parentFeature',
     parentEntity: 'parentEntity',
-  } as unknown as ChildDefinition<SmartNgRXRowBase>;
+  } as unknown as ChildDefinition<
+    SmartNgRXRowBase,
+    string,
+    string,
+    string,
+    string,
+    { id: string; name: string; isDirty: boolean }
+  >;
   entityDefinitionCache('feature', 'entity', {
     entityName: 'entity',
     entityAdapter: createEntityAdapter(),

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
@@ -26,7 +26,7 @@ export function realOrMocked<
   entityState: EntityState<T>,
   id: string,
   defaultObject: T,
-  childDefinition: ChildDefinition<P>,
+  childDefinition: ChildDefinition<P, string, string, string, string, T>,
 ): T {
   const { childFeature, childEntity, parentFeature, parentEntity } =
     childDefinition;

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
@@ -4,6 +4,7 @@ import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { rowProxy } from '../row-proxy/row-proxy.function';
+import { RowProxyDelete } from '../row-proxy/row-proxy-delete.interface';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
@@ -27,7 +28,7 @@ export function realOrMocked<
   id: string,
   defaultObject: T,
   childDefinition: ChildDefinition<P, string, string, string, string, T>,
-): T {
+): RowProxyDelete & T {
   const { childFeature, childEntity, parentFeature, parentEntity } =
     childDefinition;
   const service = castTo<ActionService<T>>(
@@ -38,9 +39,9 @@ export function realOrMocked<
   );
 
   const record = entityState.entities;
-  const row = record[id];
+  let row = record[id];
   if (row === undefined) {
-    return { ...defaultObject, id };
+    row = { ...defaultObject, id };
   }
   return rowProxy<T, P>(row, service, parentService);
 }

--- a/libs/smart-ngrx/src/selector/smart-array.interface.ts
+++ b/libs/smart-ngrx/src/selector/smart-array.interface.ts
@@ -1,0 +1,10 @@
+import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
+
+export interface SmartArray<
+  P extends object = object,
+  C extends SmartNgRXRowBase = SmartNgRXRowBase,
+> {
+  rawArray?: string[];
+  addToStore?(newRow: C, thisRow: P): void;
+  removeFromStore?(row: C, parent: P): void;
+}

--- a/libs/smart-ngrx/src/types/child-definition.interface.ts
+++ b/libs/smart-ngrx/src/types/child-definition.interface.ts
@@ -1,4 +1,5 @@
 import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
+import { SmartNgRXRowBase } from './smart-ngrx-row-base.interface';
 import { SmartNgRXRowBaseSelector } from './smart-ngrx-row-base-selector.type';
 
 /**
@@ -10,6 +11,7 @@ export interface ChildDefinition<
   CE extends string = string,
   PF extends string = string,
   PE extends string = string,
+  T extends SmartNgRXRowBase = SmartNgRXRowBase,
 > {
   /**
    * The name of the feature that contains the child data.
@@ -22,7 +24,7 @@ export interface ChildDefinition<
   /**
    *  The selector to retrieve the child data from the store.
    */
-  childSelector: SmartNgRXRowBaseSelector;
+  childSelector: SmartNgRXRowBaseSelector<T>;
 
   /**
    * The name of the field in the parent that contains the child IDs

--- a/libs/smart-ngrx/src/types/smart-ngrx-row-base-selector.type.ts
+++ b/libs/smart-ngrx/src/types/smart-ngrx-row-base-selector.type.ts
@@ -9,8 +9,5 @@ import { SmartNgRXRowBase } from './smart-ngrx-row-base.interface';
  *
  * @see SmartNgRXRowBase
  */
-export type SmartNgRXRowBaseSelector = MemoizedSelector<
-  object,
-  EntityState<SmartNgRXRowBase>,
-  DefaultProjectorFn<EntityState<SmartNgRXRowBase>>
->;
+export type SmartNgRXRowBaseSelector<T extends SmartNgRXRowBase> =
+  MemoizedSelector<object, EntityState<T>, DefaultProjectorFn<EntityState<T>>>;


### PR DESCRIPTION
# Issue Number: #487

# Body

Cast are no longer necessary to use SmartNgRX



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified selectors by removing `castTo` function and direct use of selectors.
  - Renamed `TreeStandardState` interface to `TreeStandardState2`.

- **New Features**
  - Introduced `RowProxyDelete` interface for better handling row deletions.

- **Documentation**
  - Updated references from `CustomProxy` to `RowProxy` in guides on deleting rows.

- **Chores**
  - Improved type annotations and method calls for better code clarity and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->