### PR TITLE
refactor: reduce smartngrx internal casting

### DIFF
--- a/libs/smart-ngrx/src/actions/action.service.ts
+++ b/libs/smart-ngrx/src/actions/action.service.ts
@@ -38,7 +38,7 @@ export class ActionService<
    * entityAdapter is needed for delete
    */
   entityAdapter: EntityAdapter<SmartNgRXRowBase>;
-  entities: Observable<Dictionary<T>>;
+  entities: Observable<Dictionary<SmartNgRXRowBase>>;
   private actions: ActionGroup<T>;
   private store = storeFunction();
   private markDirtyFetchesNew = true;
@@ -64,9 +64,7 @@ export class ActionService<
     const selectEntity = createSelector(selectFeature, (f) => f[this.entity]);
     const selectEntities = this.entityAdapter.getSelectors().selectEntities;
     const selectFeatureEntities = createSelector(selectEntity, selectEntities);
-    this.entities = castTo<Observable<Dictionary<T>>>(
-      this.store.select(selectFeatureEntities),
-    );
+    this.entities = this.store.select(selectFeatureEntities);
 
     const registry = getEntityRegistry(feature, entity);
     this.markDirtyFetchesNew =
@@ -103,7 +101,7 @@ export class ActionService<
    */
   forceDirty(ids: string[]): void {
     this.entities.pipe(take(1)).subscribe((entities) => {
-      this.markDirtyWithEntities<T>(entities, ids);
+      this.markDirtyWithEntities(entities, ids);
     });
   }
 

--- a/libs/smart-ngrx/src/common/zoneless.function.ts
+++ b/libs/smart-ngrx/src/common/zoneless.function.ts
@@ -1,5 +1,4 @@
 import { assert } from './assert.function';
-import { castTo } from './cast-to.function';
 import { isNullOrUndefined } from './is-null-or-undefined.function';
 
 /**
@@ -9,8 +8,8 @@ import { isNullOrUndefined } from './is-null-or-undefined.function';
  * @returns the zoneless version of the function
  */
 export function zoneless(func: string): unknown {
-  const windowRecord = castTo<Record<string, unknown>>(window);
-  const zonelessSymbol = windowRecord['__zone_symbol__' + func];
+  const zonelessSymbol =
+    window[('__zone_symbol__' + func) as keyof typeof window];
   /* istanbul ignore next -- can only be triggered at runtime without some hacking mocking for trivial code */
   if (isNullOrUndefined(zonelessSymbol)) {
     switch (func) {

--- a/libs/smart-ngrx/src/effects/effects-factory.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory.function.ts
@@ -1,10 +1,7 @@
 import { InjectionToken } from '@angular/core';
 import { createEffect, EffectConfig, FunctionalEffect } from '@ngrx/effects';
-import { EntityAdapter } from '@ngrx/entity';
 
 import { actionFactory } from '../actions/action.factory';
-import { assert } from '../common/assert.function';
-import { castTo } from '../common/cast-to.function';
 import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
@@ -55,12 +52,9 @@ export function effectsFactory<
   effectsServiceToken: InjectionToken<EffectService<T>>,
 ): Record<string, FunctionalEffect> {
   const actions = actionFactory<T, F, E>(feature, entityName);
-  const entityDefinition = entityDefinitionCache(feature, entityName);
-  const adapter = castTo<EntityAdapter<T> | undefined>(
-    entityDefinition.entityAdapter,
-  );
-  assert(!!adapter, `Missing adapter for ${feature}:${entityName}.`);
-  return castTo<Record<string, FunctionalEffect>>({
+  const entityDefinition = entityDefinitionCache<T>(feature, entityName);
+  const adapter = entityDefinition.entityAdapter;
+  return {
     delete: createEffect(
       deleteEffect(effectsServiceToken, actions),
       dispatchFalse,
@@ -89,8 +83,8 @@ export function effectsFactory<
     ),
     add: createEffect(addEffect(effectsServiceToken, actions), dispatchTrue),
     addSuccess: createEffect(
-      addSuccessEffect(effectsServiceToken, actions, adapter),
+      addSuccessEffect<T>(effectsServiceToken, actions, adapter),
       dispatchFalse,
     ),
-  });
+  };
 }

--- a/libs/smart-ngrx/src/effects/effects-factory/add-success-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/add-success-effect.function.ts
@@ -20,7 +20,7 @@ import { markParentsDirty } from './mark-parents-dirty.function';
  *
  * @returns The effect that will be called when the action is triggered
  */
-export function addSuccessEffect<T extends SmartNgRXRowBase>(
+export function addSuccessEffect<T extends SmartNgRXRowBase = SmartNgRXRowBase>(
   effectServiceToken: InjectionToken<EffectService<T>>,
   actions: ActionGroup<T>,
   adapter: EntityAdapter<T>,

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.ts
@@ -62,7 +62,7 @@ export function updateEffect<T extends SmartNgRXRowBase>(
       scan(
         (acc, action) => ({
           ...acc,
-          [castTo<{ id: string }>(action.old.row).id]: action,
+          [action.old.row.id]: action,
         }),
         {} as Record<string, { old: RowProp<T>; new: RowProp<T> }>,
       ),

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.ts
@@ -12,7 +12,6 @@ import {
 } from 'rxjs';
 
 import { ActionGroup } from '../../actions/action-group.interface';
-import { castTo } from '../../common/cast-to.function';
 import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 import { RowProp } from '../../types/row-prop.interface';
@@ -86,7 +85,7 @@ export function updateEffect<T extends SmartNgRXRowBase>(
         // rows only has one row it it we just return an array
         // so we can reuse code.
         const now = Date.now();
-        const id = castTo<{ id: string }>(rows[0]).id;
+        const id = rows[0].id;
         // delete the timeout to keep things in order.
         lastRowTimeout.delete(id);
         lastRowTimeout.set(id, now);

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect/manage-maps.function.spec.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect/manage-maps.function.spec.ts
@@ -1,7 +1,13 @@
+import { SmartNgRXRowBase } from '../../../types/smart-ngrx-row-base.interface';
 import { manageMaps } from './manage-maps.function';
 
+interface Row extends SmartNgRXRowBase {
+  id: string;
+  name: string;
+}
+
 describe('manage-maps.function.ts', () => {
-  const lastRow = new Map<string, object>();
+  const lastRow = new Map<string, Row>();
   const lastRowTimeout = new Map<string, number>();
   let now = Date.now();
   describe('when I add a new row to the maps', () => {

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect/manage-maps.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect/manage-maps.function.ts
@@ -1,5 +1,5 @@
-import { castTo } from '../../../common/cast-to.function';
 import { RowProp } from '../../../types/row-prop.interface';
+import { SmartNgRXRowBase } from '../../../types/smart-ngrx-row-base.interface';
 
 /**
  * Helper function that updates the maps used in update-effect.function.ts
@@ -12,7 +12,7 @@ import { RowProp } from '../../../types/row-prop.interface';
  * @param action.old the row the new row is replacing
  * @param action.new the new row we are sending to the server
  */
-export function manageMaps<T>(
+export function manageMaps<T extends SmartNgRXRowBase>(
   lastRow: Map<string, T>,
   lastRowTimeout: Map<string, number>,
   action: {
@@ -34,7 +34,7 @@ export function manageMaps<T>(
     lastRow.delete(key);
   }
   // for now we assume everything has a primary key of id.
-  const id = castTo<{ id: string }>(action.old.row).id;
+  const id = action.old.row.id;
   if (!lastRowTimeout.has(id)) {
     lastRowTimeout.set(id, now);
     lastRow.set(id, action.old.row);

--- a/libs/smart-ngrx/src/registrations/entity-definition-cache.function.ts
+++ b/libs/smart-ngrx/src/registrations/entity-definition-cache.function.ts
@@ -24,11 +24,13 @@ const entityDefinitionMap = new Map<
  *
  * @see `EntityDefinition`
  */
-export function entityDefinitionCache(
+export function entityDefinitionCache<
+  T extends SmartNgRXRowBase = SmartNgRXRowBase,
+>(
   featureName: string,
   entityName: string,
   entityDefinition?: SmartEntityDefinition<SmartNgRXRowBase>,
-): SmartValidatedEntityDefinition<SmartNgRXRowBase> {
+): SmartValidatedEntityDefinition<T> {
   let cached = entityDefinitionMap.get(`${featureName}${psi}${entityName}`);
   if (entityDefinition !== undefined) {
     cached = entityDefinition;
@@ -50,5 +52,5 @@ export function entityDefinitionCache(
     `Entity adapter for ${featureName}${psi}${entityName} not found.`,
   );
   // we can cast this now because we've validated that it obeys the type rules
-  return castTo<SmartValidatedEntityDefinition<SmartNgRXRowBase>>(cached);
+  return castTo<SmartValidatedEntityDefinition<T>>(cached);
 }

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.spec.ts
@@ -22,7 +22,7 @@ describe('customProxyGet()', () => {
       b: 'c',
     },
     row: {},
-  } as unknown as RowProxy<object>;
+  } as unknown as RowProxy;
   const service = {
     loadByIdsSuccess: () => {
       /*noop*/

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.spec.ts
@@ -11,7 +11,7 @@ interface CRow extends SmartNgRXRowBase {
 interface TRow extends SmartNgRXRowBase {
   id: string;
   name: string;
-  children: ArrayProxy<object, CRow>;
+  children: ArrayProxy<SmartNgRXRowBase, CRow>;
 }
 
 describe('RowProxy', () => {
@@ -20,7 +20,10 @@ describe('RowProxy', () => {
     const row = {
       id: '1',
       name: 'test',
-      children: ['child1a', 'child2a'] as unknown as ArrayProxy<object, CRow>,
+      children: ['child1a', 'child2a'] as unknown as ArrayProxy<
+        SmartNgRXRowBase,
+        CRow
+      >,
     };
     row.children.rawArray = ['child1', 'child2'];
     customProxy = new RowProxy<TRow, CRow>(

--- a/libs/smart-ngrx/src/selector/array-proxy-class.get.function.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy-class.get.function.ts
@@ -9,7 +9,7 @@ import { ArrayProxy } from './array-proxy.class';
  * @returns The value of the property.
  */
 export function arrayProxyClassGet<
-  P extends object,
+  P extends SmartNgRXRowBase,
   C extends SmartNgRXRowBase,
 >(target: ArrayProxy<P, C>, prop: string | symbol): unknown {
   if (typeof prop === 'string' && !Number.isNaN(+prop)) {

--- a/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
@@ -36,7 +36,10 @@ describe('ArrayProxy', () => {
 
     getArrayItemSpy = jest
       .spyOn(getArrayItem, 'getArrayItem')
-      .mockImplementation(() => ({}));
+      .mockImplementation(() => ({
+        id: '1',
+        delete: jest.fn(),
+      }));
     createStore();
     entityDefinitionCache(
       childDefinition.childFeature,
@@ -56,7 +59,7 @@ describe('ArrayProxy', () => {
       describe('and it is not frozen', () => {
         beforeEach(() => {
           originalArray = ['1', '2', '3'];
-          arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+          arrayProxy = new ArrayProxy(
             originalArray,
             { ids: [], entities: {} },
             childDefinition,
@@ -77,7 +80,7 @@ describe('ArrayProxy', () => {
         beforeEach(() => {
           originalArray = ['1', '2', '3'];
           Object.freeze(originalArray);
-          arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+          arrayProxy = new ArrayProxy(
             originalArray,
             { ids: [], entities: {} },
             childDefinition,
@@ -99,13 +102,13 @@ describe('ArrayProxy', () => {
       describe('and it is not frozen', () => {
         beforeEach(() => {
           originalArray = ['1', '2', '3'];
-          arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+          arrayProxy = new ArrayProxy(
             originalArray,
             { ids: [], entities: {} },
             childDefinition,
           );
           arrayProxy.init();
-          arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+          arrayProxy = new ArrayProxy(
             arrayProxy,
             { ids: [], entities: {} },
             childDefinition,
@@ -128,7 +131,7 @@ describe('ArrayProxy', () => {
     describe('when the index is between 0 and the length of the array', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
-        arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+        arrayProxy = new ArrayProxy(
           originalArray,
           { ids: [], entities: {} },
           childDefinition,
@@ -146,7 +149,7 @@ describe('ArrayProxy', () => {
     describe('when the index is negative', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
-        arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+        arrayProxy = new ArrayProxy(
           originalArray,
           { ids: [], entities: {} },
           childDefinition,
@@ -163,7 +166,7 @@ describe('ArrayProxy', () => {
     describe('when the index is length or greater', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
-        arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+        arrayProxy = new ArrayProxy(
           originalArray,
           { ids: [], entities: {} },
           childDefinition,
@@ -182,7 +185,7 @@ describe('ArrayProxy', () => {
     describe('when parent is not a RowProxy', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
-        arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+        arrayProxy = new ArrayProxy(
           originalArray,
           { ids: [], entities: {} },
           childDefinition,
@@ -211,7 +214,7 @@ describe('ArrayProxy', () => {
     describe('when parent is a RowProxy', () => {
       beforeEach(() => {
         originalArray = ['1', '2', '3'];
-        arrayProxy = new ArrayProxy<object, SmartNgRXRowBase>(
+        arrayProxy = new ArrayProxy(
           originalArray,
           { ids: [], entities: {} },
           childDefinition,

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -21,7 +21,7 @@ import { isArrayProxy } from './is-array-proxy.function';
  * @see `createSmartSelector`
  */
 export class ArrayProxy<
-    P extends object = object,
+    P extends SmartNgRXRowBase = SmartNgRXRowBase,
     C extends SmartNgRXRowBase = SmartNgRXRowBase,
   >
   implements ArrayLike<C>, Iterable<C>

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -18,6 +18,10 @@ import { isArrayProxy } from './is-array-proxy.function';
  * that represents the child array with a class that manages all the
  * magic of loading the data from the server as it is accessed.
  *
+ * Note: The constructor of this class returns a Proxy to intercept
+ * property accesses. This is an intentional and necessary design
+ * choice to achieve the desired behavior of dynamically loading data.
+ *
  * @see `createSmartSelector`
  */
 export class ArrayProxy<

--- a/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
@@ -29,7 +29,7 @@ import { ParentSelector } from './parent-selector.type';
  * @see `ParentSelector`
  */
 export function createInnerSmartSelector<
-  P extends object,
+  P extends SmartNgRXRowBase,
   C extends SmartNgRXRowBase,
 >(
   parentSelector: ParentSelector<P>,

--- a/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
@@ -28,7 +28,7 @@ import { ParentSelector } from './parent-selector.type';
  * @see `ParentSelector`
  */
 export function createSmartSelector<
-  P extends object,
+  P extends SmartNgRXRowBase,
   T extends SmartNgRXRowBase,
 >(
   parentSelector: ParentSelector<P>,

--- a/libs/smart-ngrx/src/selector/is-array-proxy.function.ts
+++ b/libs/smart-ngrx/src/selector/is-array-proxy.function.ts
@@ -9,8 +9,9 @@ import { ArrayProxy } from './array-proxy.class';
  *
  * @param arr the object to check
  */
-export function isArrayProxy<P extends object, C extends SmartNgRXRowBase>(
-  arr: unknown,
-): arr is ArrayProxy<P, C> {
+export function isArrayProxy<
+  P extends SmartNgRXRowBase,
+  C extends SmartNgRXRowBase,
+>(arr: unknown): arr is ArrayProxy<P, C> {
   return !!castTo<Record<string, boolean>>(arr)[isProxy];
 }

--- a/libs/smart-ngrx/src/types/row-prop.interface.ts
+++ b/libs/smart-ngrx/src/types/row-prop.interface.ts
@@ -1,8 +1,10 @@
+import { SmartNgRXRowBase } from './smart-ngrx-row-base.interface';
+
 /**
  * Interface for `Actions` that take a row property
  *
  * @see `actionFactory`
  */
-export interface RowProp<T> {
+export interface RowProp<T extends SmartNgRXRowBase> {
   row: T;
 }

--- a/libs/smart-ngrx/src/types/smart-entity-definition.interface.ts
+++ b/libs/smart-ngrx/src/types/smart-entity-definition.interface.ts
@@ -60,12 +60,12 @@ export interface SmartEntityDefinition<Row extends SmartNgRXRowBase> {
   markAndDelete?: Partial<MarkAndDeleteInit>;
 }
 
-interface ValidOptionalEntityDefinition {
-  entityAdapter: EntityAdapter<SmartNgRXRowBase>;
+interface ValidOptionalEntityDefinition<T extends SmartNgRXRowBase> {
+  entityAdapter: EntityAdapter<T>;
 }
 
 export type SmartValidatedEntityDefinition<Row extends SmartNgRXRowBase> = Omit<
   SmartEntityDefinition<Row>,
   'entityAdapter'
 > &
-  ValidOptionalEntityDefinition;
+  ValidOptionalEntityDefinition<Row>;

--- a/libs/smart-ngrx/src/types/smart-ngrx-row-base.interface.ts
+++ b/libs/smart-ngrx/src/types/smart-ngrx-row-base.interface.ts
@@ -5,6 +5,10 @@
  */
 export interface SmartNgRXRowBase {
   /**
+   * All rows need an id field that is a string
+   */
+  id: string;
+  /**
    * Flag that indicates that the row is dirty. This is used
    * internally by the mark and delete functionality.
    */


### PR DESCRIPTION
# Issue Number: #488

# Body

Refactoring to reduce the number of castTo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved type constraints in various functions and classes to improve type safety and simplify code maintenance.

- **Improvements**
  - Enhanced type definitions for better integration and reduced need for type casting.
  - Added an `id` field to the `SmartNgRXRowBase` interface to standardize row identification.
  - Updated the `ArrayProxy` class and related functions to use more specific type constraints for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->