### PR TITLE
refactor: reduce castto usage in smartngrx lib part 2

### DIFF
--- a/libs/smart-ngrx/src/actions/action-group.interface.ts
+++ b/libs/smart-ngrx/src/actions/action-group.interface.ts
@@ -2,7 +2,6 @@
 /* jscpd:ignore-start */
 import { Action, ActionCreator } from '@ngrx/store';
 
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { IdsProp } from '../types/ids-prop.interface';
 import { RowProp } from '../types/row-prop.interface';
 import { RowsProp } from '../types/rows-prop.interface';
@@ -45,13 +44,13 @@ export interface ActionGroup<T extends SmartNgRXRowBase> {
     (props: {
       row: T;
       parentId: string;
-      parentFeature: StringLiteralSource<string>;
-      parentEntityName: StringLiteralSource<string>;
+      parentFeature: string;
+      parentEntityName: string;
     }) => Action<`[${any}] Add`> & {
       row: T;
       parentId: string;
-      parentFeature: StringLiteralSource<string>;
-      parentEntityName: StringLiteralSource<string>;
+      parentFeature: string;
+      parentEntityName: string;
     }
   >;
   addSuccess: ActionCreator<
@@ -60,14 +59,14 @@ export interface ActionGroup<T extends SmartNgRXRowBase> {
       oldRow: T;
       newRow: T;
       parentId: string;
-      parentFeature: StringLiteralSource<string>;
-      parentEntityName: StringLiteralSource<string>;
+      parentFeature: string;
+      parentEntityName: string;
     }) => Action<`[${any}] Add Success`> & {
       oldRow: T;
       newRow: T;
       parentId: string;
-      parentFeature: StringLiteralSource<string>;
-      parentEntityName: StringLiteralSource<string>;
+      parentFeature: string;
+      parentEntityName: string;
     }
   >;
   delete: ActionCreator<

--- a/libs/smart-ngrx/src/actions/action.factory.ts
+++ b/libs/smart-ngrx/src/actions/action.factory.ts
@@ -3,7 +3,6 @@
 import { createActionGroup, props } from '@ngrx/store';
 
 import { psi } from '../common/theta.const';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { IdsProp } from '../types/ids-prop.interface';
 import { RowProp } from '../types/row-prop.interface';
 import { RowsProp } from '../types/rows-prop.interface';
@@ -27,13 +26,9 @@ const actionGroupCache = new Map<string, unknown>();
  * @see `RowProp`
  * @see `RowsProp`
  */
-export function actionFactory<
-  T extends SmartNgRXRowBase,
-  Feature extends string = string,
-  Entity extends string = string,
->(
-  feature: StringLiteralSource<Feature>,
-  entity: StringLiteralSource<Entity>,
+export function actionFactory<T extends SmartNgRXRowBase>(
+  feature: string,
+  entity: string,
 ): ActionGroup<T> {
   const source = `${feature}${psi}${entity}`;
   const cached = actionGroupCache.get(source) as ActionGroup<T> | undefined;
@@ -54,15 +49,15 @@ export function actionFactory<
       Add: props<{
         row: T;
         parentId: string;
-        parentFeature: StringLiteralSource<string>;
-        parentEntityName: StringLiteralSource<string>;
+        parentFeature: string;
+        parentEntityName: string;
       }>(),
       'Add Success': props<{
         newRow: T;
         oldRow: T;
         parentId: string;
-        parentFeature: StringLiteralSource<string>;
-        parentEntityName: StringLiteralSource<string>;
+        parentFeature: string;
+        parentEntityName: string;
       }>(),
       Delete: props<{
         id: string;

--- a/libs/smart-ngrx/src/actions/action.service.spec.ts
+++ b/libs/smart-ngrx/src/actions/action.service.spec.ts
@@ -3,7 +3,6 @@ import { createEntityAdapter, Dictionary } from '@ngrx/entity';
 import { Store } from '@ngrx/store';
 
 import { castTo } from '../common/cast-to.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import {
   registerEntity,
@@ -53,10 +52,7 @@ describe('ActionService', () => {
       entityAdapter: createEntityAdapter(),
     } as unknown as SmartEntityDefinition<Row>);
     service = castTo<PublicMarkDirtyWithEntities>(
-      new ActionService<Row>(
-        feature as StringLiteralSource<string>,
-        entity as StringLiteralSource<string>,
-      ),
+      new ActionService<Row>(feature, entity),
     );
   });
   afterEach(() => {
@@ -187,10 +183,7 @@ describe('ActionService', () => {
           } as MarkAndDeleteInit,
         } as EntityAttributes);
         service = castTo<PublicMarkDirtyWithEntities>(
-          new ActionService<Row>(
-            feature as StringLiteralSource<string>,
-            entity as StringLiteralSource<string>,
-          ),
+          new ActionService<Row>(feature, entity),
         );
         markDirtyWithEntitiesSpy = jest.spyOn(service, 'markDirtyWithEntities');
         service.markDirty(['1']);
@@ -211,10 +204,7 @@ describe('ActionService', () => {
           } as MarkAndDeleteInit,
         } as EntityAttributes);
         service = castTo<PublicMarkDirtyWithEntities>(
-          new ActionService<Row>(
-            feature as StringLiteralSource<string>,
-            entity as StringLiteralSource<string>,
-          ),
+          new ActionService<Row>(feature, entity),
         );
         markDirtyWithEntitiesSpy = jest.spyOn(service, 'markDirtyWithEntities');
         service.markDirty(['1']);
@@ -233,10 +223,7 @@ describe('ActionService', () => {
           markAndDeleteInit: {},
         } as EntityAttributes);
         service = castTo<PublicMarkDirtyWithEntities>(
-          new ActionService<Row>(
-            feature as StringLiteralSource<string>,
-            entity as StringLiteralSource<string>,
-          ),
+          new ActionService<Row>(feature, entity),
         );
         markDirtyWithEntitiesSpy = jest.spyOn(service, 'markDirtyWithEntities');
         service.markDirty(['1']);

--- a/libs/smart-ngrx/src/actions/action.service.ts
+++ b/libs/smart-ngrx/src/actions/action.service.ts
@@ -10,7 +10,6 @@ import {
   registerEntityRows,
   unregisterEntityRows,
 } from '../mark-and-delete/register-entity-rows.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { defaultRows } from '../reducers/default-rows.function';
 import { childDefinitionRegistry } from '../registrations/child-definition.registry';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
@@ -29,11 +28,7 @@ import { removeIdFromParents } from './remove-id-from-parents.function';
  * to the store, and keeps logic out of the reducer and effects without
  * scattering the logic throughout the application.
  */
-export class ActionService<
-  T extends SmartNgRXRowBase,
-  Feature extends string = string,
-  Entity extends string = string,
-> {
+export class ActionService<T extends SmartNgRXRowBase> {
   /**
    * entityAdapter is needed for delete
    */
@@ -50,8 +45,8 @@ export class ActionService<
    * @param entity the name of the entity this class is for
    */
   constructor(
-    public feature: StringLiteralSource<Feature>,
-    public entity: StringLiteralSource<Entity>,
+    public feature: string,
+    public entity: string,
   ) {
     this.actions = actionFactory(feature, entity);
     const selectFeature = createFeatureSelector<Record<string, EntityState<T>>>(

--- a/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
@@ -49,7 +49,7 @@ describe('removeIdFromParents()', () => {
       childFeature: 'feature' as StringLiteralSource<string>,
       parentEntity: 'parentEntity' as StringLiteralSource<string>,
       parentFeature: 'parentFeature' as StringLiteralSource<string>,
-    } as unknown as ChildDefinition<SmartNgRXRowBase>);
+    } as unknown as ChildDefinition);
     parentServiceUpdateManySpy = jest
       .spyOn(parentService, 'updateMany')
       .mockImplementation(() => {

--- a/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
@@ -1,4 +1,3 @@
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { childDefinitionRegistry } from '../registrations/child-definition.registry';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
@@ -45,10 +44,10 @@ describe('removeIdFromParents()', () => {
     } as unknown as ActionService<SmartNgRXRowBase>;
     childDefinitionRegistry.registerChildDefinition('feature', 'entity', {
       parentField: 'children',
-      childEntity: 'entity' as StringLiteralSource<string>,
-      childFeature: 'feature' as StringLiteralSource<string>,
-      parentEntity: 'parentEntity' as StringLiteralSource<string>,
-      parentFeature: 'parentFeature' as StringLiteralSource<string>,
+      childEntity: 'entity',
+      childFeature: 'feature',
+      parentEntity: 'parentEntity',
+      parentFeature: 'parentFeature',
     } as unknown as ChildDefinition);
     parentServiceUpdateManySpy = jest
       .spyOn(parentService, 'updateMany')

--- a/libs/smart-ngrx/src/actions/remove-id-from-parents.function.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-parents.function.ts
@@ -16,7 +16,7 @@ import { removeIdFromFeatureParents } from './remove-id-from-feature-parents.fun
  * @param parentInfo holds the parent feature, entity, and ids that are affected by the delete
  */
 export function removeIdFromParents(
-  childDefinition: ChildDefinition<SmartNgRXRowBase>,
+  childDefinition: ChildDefinition,
   service: ActionService<SmartNgRXRowBase>,
   id: string,
   parentInfo: ParentInfo[],

--- a/libs/smart-ngrx/src/effects/effects-factory.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory.function.ts
@@ -2,7 +2,6 @@ import { InjectionToken } from '@angular/core';
 import { createEffect, EffectConfig, FunctionalEffect } from '@ngrx/effects';
 
 import { actionFactory } from '../actions/action.factory';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { EffectService } from './effect-service';
@@ -42,16 +41,12 @@ const dispatchTrue = {
  * @see `EffectsFactory`
  * @see `EffectService`
  */
-export function effectsFactory<
-  F extends string,
-  E extends string,
-  T extends SmartNgRXRowBase,
->(
-  feature: StringLiteralSource<F>,
-  entityName: StringLiteralSource<E>,
+export function effectsFactory<T extends SmartNgRXRowBase>(
+  feature: string,
+  entityName: string,
   effectsServiceToken: InjectionToken<EffectService<T>>,
 ): Record<string, FunctionalEffect> {
-  const actions = actionFactory<T, F, E>(feature, entityName);
+  const actions = actionFactory<T>(feature, entityName);
   const entityDefinition = entityDefinitionCache<T>(feature, entityName);
   const adapter = entityDefinition.entityAdapter;
   return {
@@ -64,21 +59,11 @@ export function effectsFactory<
       dispatchFalse,
     ),
     loadByIds: createEffect(
-      loadByIdsEffect(
-        effectsServiceToken,
-        actions,
-        feature as StringLiteralSource<string>,
-        entityName as StringLiteralSource<string>,
-      ),
+      loadByIdsEffect(effectsServiceToken, actions, feature, entityName),
       dispatchFalse,
     ),
     update: createEffect(
-      updateEffect<T>(
-        effectsServiceToken,
-        actions,
-        feature as StringLiteralSource<string>,
-        entityName as StringLiteralSource<string>,
-      ),
+      updateEffect<T>(effectsServiceToken, actions, feature, entityName),
       dispatchFalse,
     ),
     add: createEffect(addEffect(effectsServiceToken, actions), dispatchTrue),

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
@@ -3,7 +3,6 @@ import { Actions, ofType } from '@ngrx/effects';
 import { map, mergeMap } from 'rxjs';
 
 import { ActionGroup } from '../../actions/action-group.interface';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
 import { bufferAction } from '../buffer-action.function';
@@ -21,8 +20,8 @@ import { EffectService } from '../effect-service';
 export function loadByIdsEffect<T extends SmartNgRXRowBase>(
   effectServiceToken: InjectionToken<EffectService<T>>,
   actions: ActionGroup<T>,
-  feature: StringLiteralSource<string>,
-  entity: StringLiteralSource<string>,
+  feature: string,
+  entity: string,
 ) {
   return (
     /* istanbul ignore next -- default value, not really a condition */

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
@@ -4,7 +4,6 @@ import { EMPTY, mergeMap } from 'rxjs';
 
 import { ActionService } from '../../actions/action.service';
 import { ActionGroup } from '../../actions/action-group.interface';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
 import { bufferAction } from '../buffer-action.function';
 
@@ -17,13 +16,9 @@ import { bufferAction } from '../buffer-action.function';
  * @param actions the action group for the source provided
  * @returns the LoadByIdesPreload effect
  */
-export function loadByIdsPreloadEffect<
-  F extends string,
-  E extends string,
-  T extends SmartNgRXRowBase,
->(
-  feature: StringLiteralSource<F>,
-  entityName: StringLiteralSource<E>,
+export function loadByIdsPreloadEffect<T extends SmartNgRXRowBase>(
+  feature: string,
+  entityName: string,
   actions: ActionGroup<T>,
 ) {
   return (
@@ -36,10 +31,7 @@ export function loadByIdsPreloadEffect<
       ofType(actions.loadByIds),
       bufferAction(zone),
       mergeMap((ids) => {
-        new ActionService<T>(
-          feature as StringLiteralSource<string>,
-          entityName as StringLiteralSource<string>,
-        ).loadByIdsPreload(ids);
+        new ActionService<T>(feature, entityName).loadByIdsPreload(ids);
         return EMPTY;
       }),
     );

--- a/libs/smart-ngrx/src/effects/effects-factory/mark-feature-parents-dirty.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/mark-feature-parents-dirty.function.ts
@@ -1,7 +1,6 @@
 import { ActionGroup } from '../../actions/action-group.interface';
 import { ParentInfo } from '../../actions/parent-info.interface';
 import { forNext } from '../../common/for-next.function';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
 import { markParentsDirty } from './mark-parents-dirty.function';
 
@@ -14,10 +13,6 @@ export function markFeatureParentsDirty(
   action: ReturnType<ActionGroup<SmartNgRXRowBase>['delete']>,
 ) {
   forNext(action.parentInfo, (parentInfo: ParentInfo) => {
-    markParentsDirty(
-      parentInfo.feature as StringLiteralSource<string>,
-      parentInfo.entity as StringLiteralSource<string>,
-      parentInfo.ids,
-    );
+    markParentsDirty(parentInfo.feature, parentInfo.entity, parentInfo.ids);
   });
 }

--- a/libs/smart-ngrx/src/effects/effects-factory/mark-parents-dirty.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/mark-parents-dirty.function.ts
@@ -1,4 +1,3 @@
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 
 /**
@@ -9,8 +8,8 @@ import { actionServiceRegistry } from '../../registrations/action.service.regist
  * @param parentIds the ids of the parents to mark dirty
  */
 export function markParentsDirty(
-  parentFeature: StringLiteralSource<string>,
-  parentEntity: StringLiteralSource<string>,
+  parentFeature: string,
+  parentEntity: string,
   parentIds: string[],
 ): void {
   const parentService = actionServiceRegistry(parentFeature, parentEntity);

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
@@ -44,7 +44,7 @@ class TestService extends EffectService<Row> {
 }
 
 const serviceToken = new InjectionToken<TestService>('TestService');
-const actions = actionFactory<Row, 'feature', 'entity'>('feature', 'entity');
+const actions = actionFactory<Row>('feature', 'entity');
 
 describe('update-effect.function.ts', () => {
   const feature = 'feature';

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
@@ -6,7 +6,6 @@ import { Observable, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
 import { actionFactory, registerEntity, unregisterEntity } from '../..';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 import { entityDefinitionCache } from '../../registrations/entity-definition-cache.function';
 import { store as storeFunction } from '../../selector/store.function';
@@ -68,16 +67,8 @@ describe('update-effect.function.ts', () => {
     });
     const store = TestBed.inject(MockStore);
     storeFunction(store);
-    effect = updateEffect(
-      serviceToken,
-      actions,
-      feature as StringLiteralSource<string>,
-      entity as StringLiteralSource<string>,
-    );
-    const actionService = actionServiceRegistry(
-      'feature' as StringLiteralSource<string>,
-      'entity' as StringLiteralSource<string>,
-    );
+    effect = updateEffect(serviceToken, actions, feature, entity);
+    const actionService = actionServiceRegistry('feature', 'entity');
 
     serviceSpy = jest.spyOn(testService, 'update');
     actionServiceLoadByIdsSuccessSpy = jest.spyOn(

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.ts
@@ -12,7 +12,6 @@ import {
 } from 'rxjs';
 
 import { ActionGroup } from '../../actions/action-group.interface';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 import { RowProp } from '../../types/row-prop.interface';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
@@ -39,8 +38,8 @@ import { manageMaps } from './update-effect/manage-maps.function';
 export function updateEffect<T extends SmartNgRXRowBase>(
   effectServiceToken: InjectionToken<EffectService<T>>,
   actions: ActionGroup<T>,
-  feature: StringLiteralSource<string>,
-  entity: StringLiteralSource<string>,
+  feature: string,
+  entity: string,
 ) {
   const lastRow: Map<string, T> = new Map();
   const lastRowTimeout: Map<string, number> = new Map();
@@ -91,10 +90,7 @@ export function updateEffect<T extends SmartNgRXRowBase>(
         lastRowTimeout.set(id, now);
         lastRow.set(id, rows[0]);
         // have to call the service to pickup the registration
-        const service = actionServiceRegistry(
-          feature as StringLiteralSource<string>,
-          entity as StringLiteralSource<string>,
-        );
+        const service = actionServiceRegistry(feature, entity);
         service.loadByIdsSuccess(rows);
       }),
     );

--- a/libs/smart-ngrx/src/effects/effects-factory/watch-initial-row-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/watch-initial-row-effect.function.ts
@@ -2,7 +2,6 @@ import { EntityState } from '@ngrx/entity';
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { tap } from 'rxjs';
 
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { ensureDataLoaded } from '../../selector/ensure-data-loaded.function';
 import { store } from '../../selector/store.function';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
@@ -15,8 +14,8 @@ import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
  * @returns the effects for this feature/effect
  */
 export function watchInitialRowEffect<T extends SmartNgRXRowBase>(
-  feature: StringLiteralSource<string>,
-  entity: StringLiteralSource<string>,
+  feature: string,
+  entity: string,
 ) {
   const selectFeature =
     createFeatureSelector<Record<string, EntityState<T>>>(feature);

--- a/libs/smart-ngrx/src/functions/provide-smart-feature-entities.function.ts
+++ b/libs/smart-ngrx/src/functions/provide-smart-feature-entities.function.ts
@@ -6,7 +6,6 @@ import { ActionReducer, StoreModule } from '@ngrx/store';
 import { forNext } from '../common/for-next.function';
 import { zoneless } from '../common/zoneless.function';
 import { effectsFactory } from '../effects/effects-factory.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { reducerFactory } from '../reducers/reducer.factory';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { SmartEntityDefinition } from '../types/smart-entity-definition.interface';
@@ -38,8 +37,8 @@ const unpatchedPromise = zoneless('Promise') as typeof Promise;
  *
  * @see `EntityDefinition`
  */
-export function provideSmartFeatureEntities<F extends string>(
-  featureName: StringLiteralSource<F>,
+export function provideSmartFeatureEntities(
+  featureName: string,
   entityDefinitions: SmartEntityDefinition<SmartNgRXRowBase>[],
 ): EnvironmentProviders {
   const allEffects: Record<string, FunctionalEffect>[] = [];
@@ -54,12 +53,8 @@ export function provideSmartFeatureEntities<F extends string>(
       entityDefinition,
     );
     const { entityName, effectServiceToken } = entityDefinition;
-    const effects = effectsFactory(
-      featureName,
-      entityName as StringLiteralSource<string>,
-      effectServiceToken,
-    );
-    provideWatchInitialRowEffect<F>(
+    const effects = effectsFactory(featureName, entityName, effectServiceToken);
+    provideWatchInitialRowEffect(
       entityDefinition,
       effects,
       featureName,
@@ -67,10 +62,7 @@ export function provideSmartFeatureEntities<F extends string>(
     );
 
     allEffects.push(effects);
-    const reducer = reducerFactory(
-      featureName,
-      entityName as StringLiteralSource<string>,
-    );
+    const reducer = reducerFactory(featureName, entityName);
     reducers[entityName] = reducer;
     void unpatchedPromise.resolve().then(() => {
       delayedRegisterEntity(featureName, entityName, entityDefinition);

--- a/libs/smart-ngrx/src/functions/provide-smart-ngrx.function.ts
+++ b/libs/smart-ngrx/src/functions/provide-smart-ngrx.function.ts
@@ -1,7 +1,6 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { provideEffects } from '@ngrx/effects';
 
-import { castTo } from '../common/cast-to.function';
 import { isNullOrUndefined } from '../common/is-null-or-undefined.function';
 import { markAndDeleteEffect } from '../mark-and-delete/mark-and-delete.effect';
 import { registerGlobalMarkAndDeleteInit } from '../mark-and-delete/mark-and-delete-init';
@@ -51,7 +50,7 @@ export function provideSmartNgRX(
   if (isNullOrUndefined(localConfig.markDirtyFetchesNew)) {
     localConfig.markDirtyFetchesNew = true;
   }
-  registerGlobalMarkAndDeleteInit(castTo<MarkAndDeleteInit>(localConfig));
+  registerGlobalMarkAndDeleteInit(localConfig as MarkAndDeleteInit);
   return makeEnvironmentProviders([
     provideEffects({ store: storeEffect, markAndDelete: markAndDeleteEffect }),
   ]);

--- a/libs/smart-ngrx/src/functions/provide-watch-initial-row-effect.function.ts
+++ b/libs/smart-ngrx/src/functions/provide-watch-initial-row-effect.function.ts
@@ -1,7 +1,6 @@
 import { createEffect, FunctionalEffect } from '@ngrx/effects';
 
 import { watchInitialRowEffect } from '../effects/effects-factory/watch-initial-row-effect.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { SmartEntityDefinition } from '../types/smart-entity-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
@@ -13,19 +12,16 @@ import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
  * @param featureName The feature name
  * @param entityName The entity name
  */
-export function provideWatchInitialRowEffect<F extends string>(
+export function provideWatchInitialRowEffect(
   entityDefinition: SmartEntityDefinition<SmartNgRXRowBase>,
   effects: Record<string, FunctionalEffect>,
-  featureName: StringLiteralSource<F>,
+  featureName: string,
   entityName: string,
 ): void {
   /* istanbul ignore next -- trivial */
   if (entityDefinition.isInitialRow === true) {
     effects['watchInitialRow'] = createEffect(
-      watchInitialRowEffect(
-        featureName as StringLiteralSource<string>,
-        entityName as StringLiteralSource<string>,
-      ),
+      watchInitialRowEffect(featureName, entityName),
       { dispatch: false, functional: true },
     );
   }

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
@@ -1,7 +1,5 @@
 import { registerEntity, unregisterEntity } from '../..';
-import { castTo } from '../../common/cast-to.function';
 import { psi } from '../../common/theta.const';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { MarkAndDeleteInit } from '../../types/mark-and-delete-init.interface';
 import { registerGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
 import { markAndDeleteEntity } from './mark-and-delete-entity.function';
@@ -36,12 +34,7 @@ describe('markAndDeleteEntity', () => {
           };
         },
       });
-      markAndDeleteEntity(
-        castTo<[StringLiteralSource<string>, StringLiteralSource<string>]>([
-          'feature',
-          'entity',
-        ]),
-      );
+      markAndDeleteEntity(['feature', 'entity']);
       expect(processMarkAndDeleteSpy).toHaveBeenCalledWith(
         'feature',
         'entity',
@@ -74,12 +67,7 @@ describe('markAndDeleteEntity', () => {
           };
         },
       });
-      markAndDeleteEntity(
-        castTo<[StringLiteralSource<string>, StringLiteralSource<string>]>([
-          'feature',
-          'entity',
-        ]),
-      );
+      markAndDeleteEntity(['feature', 'entity']);
       expect(processMarkAndDeleteSpy).toHaveBeenCalledWith(
         'feature',
         'entity',
@@ -106,12 +94,7 @@ describe('markAndDeleteEntity', () => {
           };
         },
       });
-      markAndDeleteEntity(
-        castTo<[StringLiteralSource<string>, StringLiteralSource<string>]>([
-          'feature',
-          'entity',
-        ]),
-      );
+      markAndDeleteEntity(['feature', 'entity']);
       expect(processMarkAndDeleteSpy).toHaveBeenCalledWith(
         'feature',
         'entity',
@@ -138,12 +121,7 @@ describe('markAndDeleteEntity', () => {
           };
         },
       });
-      markAndDeleteEntity(
-        castTo<[StringLiteralSource<string>, StringLiteralSource<string>]>([
-          'feature',
-          'entity',
-        ]),
-      );
+      markAndDeleteEntity(['feature', 'entity']);
       expect(processMarkAndDeleteSpy).toHaveBeenCalledWith(
         'feature',
         'entity',
@@ -170,12 +148,7 @@ describe('markAndDeleteEntity', () => {
           };
         },
       });
-      markAndDeleteEntity(
-        castTo<[StringLiteralSource<string>, StringLiteralSource<string>]>([
-          'feature',
-          'entity',
-        ]),
-      );
+      markAndDeleteEntity(['feature', 'entity']);
       expect(processMarkAndDeleteSpy).toHaveBeenCalledWith(
         'feature',
         'entity',

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
@@ -34,7 +34,7 @@ describe('markAndDeleteEntity', () => {
           };
         },
       });
-      markAndDeleteEntity(['feature', 'entity']);
+      markAndDeleteEntity(['feature', 'entity'] as [string, string]);
       expect(processMarkAndDeleteSpy).toHaveBeenCalledWith(
         'feature',
         'entity',

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.ts
@@ -1,5 +1,4 @@
 import { getEntityRegistry } from '../..';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { getGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
 import { processMarkAndDelete } from './process-mark-and-delete.function';
 
@@ -10,10 +9,7 @@ import { processMarkAndDelete } from './process-mark-and-delete.function';
  * @param root0."0" the feature we are processing
  * @param root0."1" the entity we are processing
  */
-export function markAndDeleteEntity([feature, entity]: [
-  StringLiteralSource<string>,
-  StringLiteralSource<string>,
-]): void {
+export function markAndDeleteEntity([feature, entity]: [string, string]): void {
   const registry = getEntityRegistry(feature, entity);
   const entityMap = registry.markAndDeleteEntityMap;
   const featureInit = registry.markAndDeleteInit;

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-features-interval.function.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-features-interval.function.ts
@@ -2,7 +2,6 @@ import { interval, Observable, tap } from 'rxjs';
 
 import { forNext } from '../../common/for-next.function';
 import { psi } from '../../common/theta.const';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { markAndDeleteEntities } from '../mark-and-delete-entity.map';
 import { getGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
 import { markAndDeleteEntity } from './mark-and-delete-entity.function';
@@ -20,12 +19,7 @@ export function markAndDeleteFeaturesInterval(): Observable<number> {
       const featureKeys = markAndDeleteEntities();
       // for/next is faster than forEach
       forNext(featureKeys, (item) =>
-        markAndDeleteEntity(
-          item.split(psi) as [
-            StringLiteralSource<string>,
-            StringLiteralSource<string>,
-          ],
-        ),
+        markAndDeleteEntity(item.split(psi) as [string, string]),
       );
     }),
   );

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.spec.ts
@@ -1,5 +1,4 @@
 import { ActionService } from '../../actions/action.service';
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import * as actionServiceRegistry from '../../registrations/action.service.registry';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
 import { processMarkAndDelete } from './process-mark-and-delete.function';
@@ -56,8 +55,8 @@ describe('processMarkAndDelete', () => {
 
     // Act
     processMarkAndDelete(
-      featureKey as StringLiteralSource<string>,
-      entity as StringLiteralSource<string>,
+      featureKey,
+      entity,
       garbageCollectRowIds,
       markDirtyRowIds,
     );
@@ -76,8 +75,8 @@ describe('processMarkAndDelete', () => {
 
     // Act
     processMarkAndDelete(
-      featureKey as StringLiteralSource<string>,
-      entity as StringLiteralSource<string>,
+      featureKey,
+      entity,
       garbageCollectRowIds,
       markDirtyRowIds,
     );
@@ -96,8 +95,8 @@ describe('processMarkAndDelete', () => {
 
       // Act
       processMarkAndDelete(
-        featureKey as StringLiteralSource<string>,
-        entity as StringLiteralSource<string>,
+        featureKey,
+        entity,
         garbageCollectRowIds,
         markDirtyRowIds,
       );
@@ -117,8 +116,8 @@ describe('processMarkAndDelete', () => {
 
       // Act
       processMarkAndDelete(
-        featureKey as StringLiteralSource<string>,
-        entity as StringLiteralSource<string>,
+        featureKey,
+        entity,
         garbageCollectRowIds,
         markDirtyRowIds,
       );

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.spec.ts
@@ -30,7 +30,7 @@ describe('processMarkAndDelete', () => {
     jest
       .spyOn(actionServiceRegistry, 'actionServiceRegistry')
       .mockImplementation(
-        (_: StringLiteralSource<string>, __: StringLiteralSource<string>) =>
+        (_: string, __: string) =>
           mockActionService as unknown as ActionService<SmartNgRXRowBase>,
       );
     garbageCollectSpy = jest

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.ts
@@ -1,4 +1,3 @@
-import { StringLiteralSource } from '../../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 import { getGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
 
@@ -12,8 +11,8 @@ import { getGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
  * @param markDirtyRowIds items that need to be marked dirty
  */
 export function processMarkAndDelete(
-  featureKey: StringLiteralSource<string>,
-  entity: StringLiteralSource<string>,
+  featureKey: string,
+  entity: string,
   garbageCollectRowIds: string[],
   markDirtyRowIds: string[],
 ) {

--- a/libs/smart-ngrx/src/reducers/reducer.factory.ts
+++ b/libs/smart-ngrx/src/reducers/reducer.factory.ts
@@ -2,7 +2,6 @@ import { EntityState } from '@ngrx/entity';
 import { ActionReducer, createReducer, on } from '@ngrx/store';
 
 import { actionFactory } from '../actions/action.factory';
-import { castTo } from '../common/cast-to.function';
 import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
@@ -24,28 +23,24 @@ export function reducerFactory<
   feature: StringLiteralSource<F>,
   entity: StringLiteralSource<E>,
 ): ActionReducer<EntityState<T>> {
-  const adapter = entityDefinitionCache(feature, entity).entityAdapter;
+  const adapter = entityDefinitionCache<T>(feature, entity).entityAdapter;
   const initialState = adapter.getInitialState();
   const actions = actionFactory<T, F, E>(feature, entity);
 
-  return castTo<ActionReducer<EntityState<T>>>(
-    createReducer(
-      initialState,
-      on(actions.add, (state, { row }) => adapter.upsertOne(row, state)),
-      on(actions.addSuccess, (state, { newRow }) =>
-        adapter.upsertOne(newRow, state),
-      ),
-      on(actions.updateMany, (state, { changes }) => {
-        return adapter.updateMany(changes, state);
-      }),
-      on(actions.remove, (state, { ids }) => adapter.removeMany(ids, state)),
-      on(actions.update, (state, { new: { row } }) =>
-        adapter.upsertOne(row, state),
-      ),
-
-      on(actions.storeRows, (state, { rows }) =>
-        adapter.upsertMany(rows, state),
-      ),
+  return createReducer(
+    initialState,
+    on(actions.add, (state, { row }) => adapter.upsertOne(row, state)),
+    on(actions.addSuccess, (state, { newRow }) =>
+      adapter.upsertOne(newRow, state),
     ),
+    on(actions.updateMany, (state, { changes }) => {
+      return adapter.updateMany(changes, state);
+    }),
+    on(actions.remove, (state, { ids }) => adapter.removeMany(ids, state)),
+    on(actions.update, (state, { new: { row } }) =>
+      adapter.upsertOne(row, state),
+    ),
+
+    on(actions.storeRows, (state, { rows }) => adapter.upsertMany(rows, state)),
   );
 }

--- a/libs/smart-ngrx/src/reducers/reducer.factory.ts
+++ b/libs/smart-ngrx/src/reducers/reducer.factory.ts
@@ -2,7 +2,6 @@ import { EntityState } from '@ngrx/entity';
 import { ActionReducer, createReducer, on } from '@ngrx/store';
 
 import { actionFactory } from '../actions/action.factory';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
@@ -15,17 +14,13 @@ import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
  * @param entity The entity name (source) for this reducer
  * @returns a new reducer for the source provided
  */
-export function reducerFactory<
-  F extends string,
-  E extends string,
-  T extends SmartNgRXRowBase,
->(
-  feature: StringLiteralSource<F>,
-  entity: StringLiteralSource<E>,
+export function reducerFactory<T extends SmartNgRXRowBase>(
+  feature: string,
+  entity: string,
 ): ActionReducer<EntityState<T>> {
   const adapter = entityDefinitionCache<T>(feature, entity).entityAdapter;
   const initialState = adapter.getInitialState();
-  const actions = actionFactory<T, F, E>(feature, entity);
+  const actions = actionFactory<T>(feature, entity);
 
   return createReducer(
     initialState,

--- a/libs/smart-ngrx/src/registrations/action.service.registry.ts
+++ b/libs/smart-ngrx/src/registrations/action.service.registry.ts
@@ -1,6 +1,5 @@
 import { ActionService } from '../actions/action.service';
 import { psi } from '../common/theta.const';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
 const actionServiceMap = new Map<string, ActionService<SmartNgRXRowBase>>();
@@ -13,8 +12,8 @@ const actionServiceMap = new Map<string, ActionService<SmartNgRXRowBase>>();
  * @returns the ActionService object/class for the given feature and entity
  */
 export function actionServiceRegistry(
-  feature: StringLiteralSource<string>,
-  entity: StringLiteralSource<string>,
+  feature: string,
+  entity: string,
 ): ActionService<SmartNgRXRowBase> {
   const key = `${feature}${psi}${entity}`;
   let actionServiceCache = actionServiceMap.get(key);

--- a/libs/smart-ngrx/src/registrations/child-definition.registry.ts
+++ b/libs/smart-ngrx/src/registrations/child-definition.registry.ts
@@ -4,14 +4,8 @@ import { psi } from '../common/theta.const';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
-interface ChildField {
-  childField: string;
-}
-type GenericChildDefinition = ChildField &
-  Omit<ChildDefinition<object>, 'childField'>;
-
 class ChildDefinitionRegistry {
-  private childDefinitionMap = new Map<string, GenericChildDefinition[]>();
+  private childDefinitionMap = new Map<string, ChildDefinition[]>();
 
   /**
    * Register a child definition so we can get at it later
@@ -20,10 +14,13 @@ class ChildDefinitionRegistry {
    * @param entity the entity the definition is for
    * @param childDefinition the childDefinition to register
    */
-  registerChildDefinition<P, T extends SmartNgRXRowBase>(
+  registerChildDefinition<
+    P extends SmartNgRXRowBase,
+    T extends SmartNgRXRowBase,
+  >(
     feature: string,
     entity: string,
-    childDefinition: ChildDefinition<P, string, string, string, string, T>,
+    childDefinition: ChildDefinition<P, T>,
   ): void {
     const existingEntries =
       this.childDefinitionMap.get(`${feature}${psi}${entity}`) ?? [];
@@ -31,7 +28,7 @@ class ChildDefinitionRegistry {
       `${feature}${psi}${entity}`,
       // Something in this registration code has
       // to be castTo() it might as well be this
-      castTo<GenericChildDefinition[]>([...existingEntries, childDefinition]),
+      castTo<ChildDefinition[]>([...existingEntries, childDefinition]),
     );
   }
 
@@ -42,7 +39,10 @@ class ChildDefinitionRegistry {
    * @param entity the entity the definition is for
    * @returns the previously registered child definition
    */
-  getChildDefinition<P>(feature: string, entity: string): ChildDefinition<P>[] {
+  getChildDefinition<P extends SmartNgRXRowBase>(
+    feature: string,
+    entity: string,
+  ): ChildDefinition<P>[] {
     const childDefinition = this.childDefinitionMap.get(
       `${feature}${psi}${entity}`,
     );

--- a/libs/smart-ngrx/src/registrations/child-definition.registry.ts
+++ b/libs/smart-ngrx/src/registrations/child-definition.registry.ts
@@ -29,6 +29,8 @@ class ChildDefinitionRegistry {
       this.childDefinitionMap.get(`${feature}${psi}${entity}`) ?? [];
     this.childDefinitionMap.set(
       `${feature}${psi}${entity}`,
+      // Something in this registration code has
+      // to be castTo() it might as well be this
       castTo<GenericChildDefinition[]>([...existingEntries, childDefinition]),
     );
   }

--- a/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
@@ -20,7 +20,7 @@ import * as getArrayItem from './get-array-item.function';
 const childDefinition = {
   childFeature: 'feature',
   childEntity: 'entity',
-} as unknown as ChildDefinition<SmartNgRXRowBase>;
+} as unknown as ChildDefinition;
 
 describe('ArrayProxy', () => {
   let arrayProxy: ArrayProxy | undefined;

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -46,14 +46,7 @@ export class ArrayProxy<
   constructor(
     private childArray: ArrayProxy<P, C> | string[],
     private child: EntityState<C>,
-    private childDefinition: ChildDefinition<
-      P,
-      string,
-      string,
-      string,
-      string,
-      C
-    >,
+    private childDefinition: ChildDefinition<P, C>,
   ) {
     const { childFeature, childEntity } = this.childDefinition;
     this.childActionService = castTo<ActionService<C>>(

--- a/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
@@ -33,7 +33,7 @@ export function createInnerSmartSelector<
   C extends SmartNgRXRowBase,
 >(
   parentSelector: ParentSelector<P>,
-  childDefinition: ChildDefinition<P, string, string, string, string, C>,
+  childDefinition: ChildDefinition<P, C>,
 ): MemoizedSelector<object, EntityState<P>> {
   const {
     childFeature,

--- a/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-smart-selector.function.ts
@@ -1,7 +1,6 @@
 import { EntityState } from '@ngrx/entity';
 import { MemoizedSelector } from '@ngrx/store';
 
-import { castTo } from '../common/cast-to.function';
 import { ChildDefinition } from '../types/child-definition.interface';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { createInnerSmartSelector } from './create-inner-smart-selector.function';
@@ -33,12 +32,9 @@ export function createSmartSelector<
 >(
   parentSelector: ParentSelector<P>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- easiest way to allow any string definition
-  children: ChildDefinition<P, any, any, any, any, T>[],
+  children: ChildDefinition<P, T>[],
 ): MemoizedSelector<object, EntityState<P>> {
   return children.reduce((p, child) => {
-    return createInnerSmartSelector(
-      p,
-      castTo<ChildDefinition<P, string, string, string, string, T>>(child),
-    );
+    return createInnerSmartSelector(p, child);
   }, parentSelector);
 }

--- a/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
@@ -3,7 +3,6 @@ import { createEntityAdapter } from '@ngrx/entity';
 
 import { ActionService } from '../actions/action.service';
 import { castTo } from '../common/cast-to.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import {
@@ -16,8 +15,8 @@ import { SmartEntityDefinition } from '../types/smart-entity-definition.interfac
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { ensureDataLoaded } from './ensure-data-loaded.function';
 
-const feature = 'feature' as StringLiteralSource<string>;
-const entity = 'entity' as StringLiteralSource<string>;
+const feature = 'feature';
+const entity = 'entity';
 
 interface Row extends SmartNgRXRowBase {
   id: string;

--- a/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
@@ -55,7 +55,7 @@ describe('ensureDataLoaded()', () => {
   describe('when the id is loaded', () => {
     describe('but isDirty has never been set', () => {
       beforeEach(() => {
-        ensureDataLoaded<Row, 'feature', 'entity'>(
+        ensureDataLoaded<Row>(
           { ids: [], entities: { id: { id: 'id', name: 'foo' } } },
           'id',
           'feature',
@@ -68,7 +68,7 @@ describe('ensureDataLoaded()', () => {
     });
     describe('and isDirty is true and mark dirty fetches new', () => {
       beforeEach(() => {
-        ensureDataLoaded<Row, 'feature', 'entity'>(
+        ensureDataLoaded<Row>(
           {
             ids: [],
             entities: { id: { id: 'id', name: 'foo', isDirty: true } },

--- a/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
@@ -54,7 +54,7 @@ describe('ensureDataLoaded()', () => {
   describe('when the id is loaded', () => {
     describe('but isDirty has never been set', () => {
       beforeEach(() => {
-        ensureDataLoaded<Row>(
+        ensureDataLoaded(
           { ids: [], entities: { id: { id: 'id', name: 'foo' } } },
           'id',
           'feature',

--- a/libs/smart-ngrx/src/selector/ensure-data-loaded.function.ts
+++ b/libs/smart-ngrx/src/selector/ensure-data-loaded.function.ts
@@ -1,7 +1,6 @@
 import { EntityState } from '@ngrx/entity';
 
 import { zoneless } from '../common/zoneless.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
@@ -17,20 +16,13 @@ const unpatchedPromise = zoneless('Promise') as typeof Promise;
  * @param feature The feature this row belongs to
  * @param entity The entity in the feature this row belongs to
  */
-export function ensureDataLoaded<
-  T extends SmartNgRXRowBase,
-  F extends string,
-  E extends string,
->(
+export function ensureDataLoaded<T extends SmartNgRXRowBase>(
   entityState: EntityState<T>,
   id: string,
-  feature: StringLiteralSource<F>,
-  entity: StringLiteralSource<E>,
+  feature: string,
+  entity: string,
 ): void {
-  const actionService = actionServiceRegistry(
-    feature as StringLiteralSource<string>,
-    entity as StringLiteralSource<string>,
-  );
+  const actionService = actionServiceRegistry(feature, entity);
   const ids = entityState.entities as Record<string, T>;
 
   const idsId = ids[id];

--- a/libs/smart-ngrx/src/selector/get-array-item.function.ts
+++ b/libs/smart-ngrx/src/selector/get-array-item.function.ts
@@ -23,7 +23,7 @@ export function getArrayItem<
 >(
   entityState: EntityState<T>,
   id: string,
-  childDefinition: ChildDefinition<P, string, string, string, string, T>,
+  childDefinition: ChildDefinition<P, T>,
 ): RowProxyDelete & T {
   const { childFeature, childEntity } = childDefinition;
 

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
@@ -39,10 +39,6 @@ describe('realOrMocked', () => {
     parentEntity: 'parentEntity',
   } as unknown as ChildDefinition<
     SmartNgRXRowBase,
-    string,
-    string,
-    string,
-    string,
     { id: string; name: string; isDirty: boolean }
   >;
   entityDefinitionCache('feature', 'entity', {

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
@@ -27,7 +27,7 @@ export function realOrMocked<
   entityState: EntityState<T>,
   id: string,
   defaultObject: T,
-  childDefinition: ChildDefinition<P, string, string, string, string, T>,
+  childDefinition: ChildDefinition<P, T>,
 ): RowProxyDelete & T {
   const { childFeature, childEntity, parentFeature, parentEntity } =
     childDefinition;

--- a/libs/smart-ngrx/src/socket/delete-entity.function.ts
+++ b/libs/smart-ngrx/src/socket/delete-entity.function.ts
@@ -2,7 +2,6 @@ import { ActionService } from '../actions/action.service';
 import { ParentInfo } from '../actions/parent-info.interface';
 import { removeIdFromParents } from '../actions/remove-id-from-parents.function';
 import { forNext } from '../common/for-next.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { childDefinitionRegistry } from '../registrations/child-definition.registry';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
@@ -14,10 +13,7 @@ import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
  * @param ids The ids of the rows that need to be deleted.
  */
 export function deleteEntity(feature: string, entity: string, ids: string[]) {
-  const actionService = new ActionService<SmartNgRXRowBase>(
-    feature as StringLiteralSource<string>,
-    entity as StringLiteralSource<string>,
-  );
+  const actionService = new ActionService<SmartNgRXRowBase>(feature, entity);
   const childDefinitions = childDefinitionRegistry.getChildDefinition(
     feature,
     entity,

--- a/libs/smart-ngrx/src/socket/update-entity.function.ts
+++ b/libs/smart-ngrx/src/socket/update-entity.function.ts
@@ -3,7 +3,6 @@ import { take } from 'rxjs';
 
 import { ActionService } from '../actions/action.service';
 import { forNext } from '../common/for-next.function';
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { store } from '../selector/store.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
@@ -20,10 +19,7 @@ export function updateEntity<T extends SmartNgRXRowBase>(
   entity: string,
   ids: string[],
 ): void {
-  const actionService = new ActionService<T>(
-    feature as StringLiteralSource<string>,
-    entity as StringLiteralSource<string>,
-  );
+  const actionService = new ActionService<T>(feature, entity);
   // check for feature/entities the long way to avoid triggering warnings
   // there is also no good reason to memoize the result
   const selectEntities = (state: unknown) => {

--- a/libs/smart-ngrx/src/types/child-definition.interface.ts
+++ b/libs/smart-ngrx/src/types/child-definition.interface.ts
@@ -1,4 +1,3 @@
-import { StringLiteralSource } from '../ngrx-internals/string-literal-source.type';
 import { SmartNgRXRowBase } from './smart-ngrx-row-base.interface';
 import { SmartNgRXRowBaseSelector } from './smart-ngrx-row-base-selector.type';
 
@@ -6,21 +5,17 @@ import { SmartNgRXRowBaseSelector } from './smart-ngrx-row-base-selector.type';
  * The definition of how to access the child data from a parent entity.
  */
 export interface ChildDefinition<
-  P,
-  CF extends string = string,
-  CE extends string = string,
-  PF extends string = string,
-  PE extends string = string,
+  P extends SmartNgRXRowBase = SmartNgRXRowBase,
   T extends SmartNgRXRowBase = SmartNgRXRowBase,
 > {
   /**
    * The name of the feature that contains the child data.
    */
-  childFeature: StringLiteralSource<CF>;
+  childFeature: string;
   /**
    * The fieldName we used to register the entity in the provider.
    */
-  childEntity: StringLiteralSource<CE>;
+  childEntity: string;
   /**
    *  The selector to retrieve the child data from the store.
    */
@@ -34,12 +29,12 @@ export interface ChildDefinition<
   /**
    * The feature the parent entity is in
    */
-  parentFeature: StringLiteralSource<PF>;
+  parentFeature: string;
   /**
    * The name of the parent entity
    * The parentFeature and parentEntity allow us to get access
    * to the parent adapter and other things we need
    * to add and delete items from the parent entity
    */
-  parentEntity: StringLiteralSource<PE>;
+  parentEntity: string;
 }


### PR DESCRIPTION
# Issue Number: #495

# Body

Mostly eliminated the need for string literals in an attempt to reduce the need for castTo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified type declarations from specialized types to primitive types (e.g., `StringLiteralSource<string>` to `string`) across various functions and classes.
  - Streamlined function signatures and class parameters by removing generic type constraints and simplifying input types.
  - Enhanced code readability and maintainability by removing explicit type annotations and unnecessary type arguments.

- **New Features**
  - Introduced more generalized type handling, making the functions and classes more flexible and easier to use.
  
- **Tests**
  - Updated test files to reflect the simplified type handling and cleaner function signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->