### PR TITLE
refactor: eliminate more castTo

### DIFF
--- a/apps/demo/src/app/shared/department-children/update-id-function.ts
+++ b/apps/demo/src/app/shared/department-children/update-id-function.ts
@@ -1,5 +1,3 @@
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
-
 import { DepartmentChild } from './department-child.interface';
 
 export function updateId(
@@ -9,11 +7,10 @@ export function updateId(
   idName = 'id',
 ): DepartmentChild[] {
   return rows.map((row) => {
-    // convert the row to a record so we can access the idName
-    const itemRecord = castTo<Record<string, string>>(row);
+    const id = row[idName as keyof DepartmentChild] as string;
     return {
       ...row,
-      id: `${type}:${itemRecord[idName]}`,
+      id: `${type}:${id}`,
     };
   });
 }

--- a/libs/smart-ngrx/src/actions/action-group.interface.ts
+++ b/libs/smart-ngrx/src/actions/action-group.interface.ts
@@ -9,7 +9,7 @@ import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { UpdateChanges } from '../types/update-changes.interface';
 /* jscpd:ignore-start */
 
-export interface ActionGroup<T extends SmartNgRXRowBase> {
+export interface ActionGroup<T extends SmartNgRXRowBase = SmartNgRXRowBase> {
   updateMany: ActionCreator<
     `[${any}] Update Many`,
     (

--- a/libs/smart-ngrx/src/actions/action.service.spec.ts
+++ b/libs/smart-ngrx/src/actions/action.service.spec.ts
@@ -28,7 +28,7 @@ interface PrivatesArePublic {
 }
 
 type PublicMarkDirtyWithEntities = Omit<
-  Omit<ActionService<Row>, 'markDirtyWithEntities'>,
+  Omit<ActionService, 'markDirtyWithEntities'>,
   'garbageCollectWithEntities'
 > &
   PrivatesArePublic;
@@ -52,7 +52,7 @@ describe('ActionService', () => {
       entityAdapter: createEntityAdapter(),
     } as unknown as SmartEntityDefinition<Row>);
     service = castTo<PublicMarkDirtyWithEntities>(
-      new ActionService<Row>(feature, entity),
+      new ActionService(feature, entity),
     );
   });
   afterEach(() => {
@@ -183,7 +183,7 @@ describe('ActionService', () => {
           } as MarkAndDeleteInit,
         } as EntityAttributes);
         service = castTo<PublicMarkDirtyWithEntities>(
-          new ActionService<Row>(feature, entity),
+          new ActionService(feature, entity),
         );
         markDirtyWithEntitiesSpy = jest.spyOn(service, 'markDirtyWithEntities');
         service.markDirty(['1']);
@@ -204,7 +204,7 @@ describe('ActionService', () => {
           } as MarkAndDeleteInit,
         } as EntityAttributes);
         service = castTo<PublicMarkDirtyWithEntities>(
-          new ActionService<Row>(feature, entity),
+          new ActionService(feature, entity),
         );
         markDirtyWithEntitiesSpy = jest.spyOn(service, 'markDirtyWithEntities');
         service.markDirty(['1']);
@@ -222,8 +222,9 @@ describe('ActionService', () => {
         registerEntity(feature, entity, {
           markAndDeleteInit: {},
         } as EntityAttributes);
+        // castTo make markDirtyWithEntities public
         service = castTo<PublicMarkDirtyWithEntities>(
-          new ActionService<Row>(feature, entity),
+          new ActionService(feature, entity),
         );
         markDirtyWithEntitiesSpy = jest.spyOn(service, 'markDirtyWithEntities');
         service.markDirty(['1']);

--- a/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
@@ -14,8 +14,8 @@ describe('removeIdFromParents()', () => {
   let parentServiceUpdateManySpy: jest.SpyInstance;
   let returnValue: string[];
   let entities: Partial<Record<string, Row>>;
-  let service: ActionService<SmartNgRXRowBase>;
-  let parentService: ActionService<SmartNgRXRowBase>;
+  let service: ActionService;
+  let parentService: ActionService;
   beforeEach(() => {
     entities = {
       '1': {
@@ -36,12 +36,12 @@ describe('removeIdFromParents()', () => {
     service = {
       feature: 'feature',
       entity: 'entity',
-    } as unknown as ActionService<SmartNgRXRowBase>;
+    } as unknown as ActionService;
     parentService = {
       feature: 'parentFeature',
       entity: 'parentEntity',
       updateMany: jest.fn(),
-    } as unknown as ActionService<SmartNgRXRowBase>;
+    } as unknown as ActionService;
     childDefinitionRegistry.registerChildDefinition('feature', 'entity', {
       parentField: 'children',
       childEntity: 'entity',

--- a/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.ts
@@ -17,8 +17,8 @@ import { ActionService } from './action.service';
  */
 export function removeIdFromFeatureParents(
   entities: Dictionary<SmartNgRXRowBase>,
-  service: ActionService<SmartNgRXRowBase>,
-  parentService: ActionService<SmartNgRXRowBase>,
+  service: ActionService,
+  parentService: ActionService,
   id: string,
 ): string[] {
   const mapChildIdToChildren = new Map<string, string[]>();

--- a/libs/smart-ngrx/src/actions/remove-id-from-parents.function.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-parents.function.ts
@@ -2,7 +2,6 @@ import { take } from 'rxjs';
 
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { ChildDefinition } from '../types/child-definition.interface';
-import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { ActionService } from './action.service';
 import { ParentInfo } from './parent-info.interface';
 import { removeIdFromFeatureParents } from './remove-id-from-feature-parents.function';
@@ -17,7 +16,7 @@ import { removeIdFromFeatureParents } from './remove-id-from-feature-parents.fun
  */
 export function removeIdFromParents(
   childDefinition: ChildDefinition,
-  service: ActionService<SmartNgRXRowBase>,
+  service: ActionService,
   id: string,
   parentInfo: ParentInfo[],
 ) {

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-preload-effect.function.ts
@@ -31,7 +31,7 @@ export function loadByIdsPreloadEffect<T extends SmartNgRXRowBase>(
       ofType(actions.loadByIds),
       bufferAction(zone),
       mergeMap((ids) => {
-        new ActionService<T>(feature, entityName).loadByIdsPreload(ids);
+        new ActionService(feature, entityName).loadByIdsPreload(ids);
         return EMPTY;
       }),
     );

--- a/libs/smart-ngrx/src/effects/effects-factory/mark-feature-parents-dirty.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/mark-feature-parents-dirty.function.ts
@@ -1,7 +1,6 @@
 import { ActionGroup } from '../../actions/action-group.interface';
 import { ParentInfo } from '../../actions/parent-info.interface';
 import { forNext } from '../../common/for-next.function';
-import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
 import { markParentsDirty } from './mark-parents-dirty.function';
 
 /**
@@ -10,7 +9,7 @@ import { markParentsDirty } from './mark-parents-dirty.function';
  * @param action the action that has the parentInfo in it
  */
 export function markFeatureParentsDirty(
-  action: ReturnType<ActionGroup<SmartNgRXRowBase>['delete']>,
+  action: ReturnType<ActionGroup['delete']>,
 ) {
   forNext(action.parentInfo, (parentInfo: ParentInfo) => {
     markParentsDirty(parentInfo.feature, parentInfo.entity, parentInfo.ids);

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/process-mark-and-delete.function.spec.ts
@@ -1,6 +1,5 @@
 import { ActionService } from '../../actions/action.service';
 import * as actionServiceRegistry from '../../registrations/action.service.registry';
-import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';
 import { processMarkAndDelete } from './process-mark-and-delete.function';
 // we have to supply requestIdleCallback for jest
 window.requestIdleCallback = (
@@ -30,7 +29,7 @@ describe('processMarkAndDelete', () => {
       .spyOn(actionServiceRegistry, 'actionServiceRegistry')
       .mockImplementation(
         (_: string, __: string) =>
-          mockActionService as unknown as ActionService<SmartNgRXRowBase>,
+          mockActionService as unknown as ActionService,
       );
     garbageCollectSpy = jest
       .spyOn(mockActionService, 'garbageCollect')

--- a/libs/smart-ngrx/src/registrations/action.service.registry.ts
+++ b/libs/smart-ngrx/src/registrations/action.service.registry.ts
@@ -1,8 +1,7 @@
 import { ActionService } from '../actions/action.service';
 import { psi } from '../common/theta.const';
-import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
-const actionServiceMap = new Map<string, ActionService<SmartNgRXRowBase>>();
+const actionServiceMap = new Map<string, ActionService>();
 
 /**
  * mechanism for getting the ActionService object/class for a given feature and entity
@@ -14,11 +13,11 @@ const actionServiceMap = new Map<string, ActionService<SmartNgRXRowBase>>();
 export function actionServiceRegistry(
   feature: string,
   entity: string,
-): ActionService<SmartNgRXRowBase> {
+): ActionService {
   const key = `${feature}${psi}${entity}`;
   let actionServiceCache = actionServiceMap.get(key);
   if (actionServiceCache === undefined) {
-    actionServiceCache = new ActionService<SmartNgRXRowBase>(feature, entity);
+    actionServiceCache = new ActionService(feature, entity);
     actionServiceMap.set(key, actionServiceCache);
   }
   return actionServiceCache;

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.spec.ts
@@ -1,5 +1,4 @@
 import { ActionService } from '../actions/action.service';
-import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { RowProxy } from './row-proxy.class';
 import { rowProxyGet } from './row-proxy-get.function';
 
@@ -27,7 +26,7 @@ describe('customProxyGet()', () => {
     loadByIdsSuccess: () => {
       /*noop*/
     },
-  } as unknown as ActionService<SmartNgRXRowBase>;
+  } as unknown as ActionService;
   let getRealRowSpy: jest.SpyInstance;
   let getJsonSpy: jest.SpyInstance;
   let loadByIdsSuccessSpy: jest.SpyInstance;

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-get.function.ts
@@ -10,13 +10,10 @@ import { RowProxy } from './row-proxy.class';
  * @param service the service that handles the actions for the row
  * @returns the value of the property
  */
-export function rowProxyGet<
-  T extends SmartNgRXRowBase,
-  P extends SmartNgRXRowBase,
->(
-  target: RowProxy<T, P>,
+export function rowProxyGet<T extends SmartNgRXRowBase>(
+  target: RowProxy<T>,
   prop: string | symbol,
-  service: ActionService<T>,
+  service: ActionService,
 ): unknown {
   if (prop === 'toJSON') {
     return () => target.toJSON();

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.spec.ts
@@ -6,8 +6,8 @@ import { rowProxySet } from './row-proxy-set.function';
 describe('customProxySet', () => {
   let target: RowProxy | undefined;
   let services: {
-    service: ActionService<SmartNgRXRowBase>;
-    parentService: ActionService<SmartNgRXRowBase>;
+    service: ActionService;
+    parentService: ActionService;
   };
   let serviceAddSpy: jest.SpyInstance;
   let serviceUpdateSpy: jest.SpyInstance;
@@ -28,8 +28,8 @@ describe('customProxySet', () => {
         update: () => {
           /*noop*/
         },
-      } as unknown as ActionService<SmartNgRXRowBase>,
-      parentService: {} as ActionService<SmartNgRXRowBase>,
+      } as unknown as ActionService,
+      parentService: {} as ActionService,
     };
     serviceAddSpy = jest
       .spyOn(services.service, 'add')
@@ -46,8 +46,8 @@ describe('customProxySet', () => {
     it('should return false', () => {
       expect(
         rowProxySet(target!, 'c', 'd', {
-          service: {} as ActionService<SmartNgRXRowBase>,
-          parentService: {} as ActionService<SmartNgRXRowBase>,
+          service: {} as ActionService,
+          parentService: {} as ActionService,
         }),
       ).toBe(false);
     });

--- a/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy-set.function.ts
@@ -1,5 +1,4 @@
 import { ActionService } from '../actions/action.service';
-import { castTo } from '../common/cast-to.function';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { RowProxy } from './row-proxy.class';
 
@@ -14,14 +13,11 @@ import { RowProxy } from './row-proxy.class';
  * @param services.parentService the service associated with the parent entity
  * @returns true if the property was set, false otherwise
  */
-export function rowProxySet<
-  T extends SmartNgRXRowBase,
-  P extends SmartNgRXRowBase,
->(
-  target: RowProxy<T, P>,
+export function rowProxySet<T extends SmartNgRXRowBase>(
+  target: RowProxy<T>,
   prop: string | symbol,
   value: unknown,
-  services: { service: ActionService<T>; parentService: ActionService<P> },
+  services: { service: ActionService; parentService: ActionService },
 ): boolean {
   if (!(prop in target.record)) {
     return false;
@@ -34,7 +30,7 @@ export function rowProxySet<
     services.service.add(
       { ...realRow, [prop]: value } as T,
       realRow.parentId,
-      castTo<ActionService<SmartNgRXRowBase>>(services.parentService),
+      services.parentService,
     );
     return true;
   }

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.spec.ts
@@ -15,7 +15,7 @@ interface TRow extends SmartNgRXRowBase {
 }
 
 describe('RowProxy', () => {
-  let customProxy: RowProxy<TRow, CRow> | undefined;
+  let customProxy: RowProxy<TRow> | undefined;
   beforeEach(() => {
     const row = {
       id: '1',
@@ -26,10 +26,10 @@ describe('RowProxy', () => {
       >,
     };
     row.children.rawArray = ['child1', 'child2'];
-    customProxy = new RowProxy<TRow, CRow>(
+    customProxy = new RowProxy<TRow>(
       row as unknown as TRow,
-      {} as ActionService<TRow>,
-      {} as ActionService<CRow>,
+      {} as ActionService,
+      {} as ActionService,
     );
   });
   describe('getRealRow()', () => {

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
@@ -18,10 +18,8 @@ import { rowProxySet } from './row-proxy-set.function';
  * to type T (above) the rest of our code still believes it is working
  * with the original row.
  */
-export class RowProxy<
-  T extends SmartNgRXRowBase = SmartNgRXRowBase,
-  P extends SmartNgRXRowBase = SmartNgRXRowBase,
-> implements RowProxyDelete
+export class RowProxy<T extends SmartNgRXRowBase = SmartNgRXRowBase>
+  implements RowProxyDelete
 {
   changes = {} as Record<string | symbol, unknown>;
   record: Record<string | symbol, unknown> = {};
@@ -36,8 +34,8 @@ export class RowProxy<
    */
   constructor(
     public row: T,
-    private service: ActionService<T>,
-    parentService: ActionService<P>,
+    private service: ActionService,
+    parentService: ActionService,
   ) {
     this.record = castTo<Record<string | symbol, unknown>>(row);
     return new Proxy(this, {

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.function.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.function.ts
@@ -18,13 +18,10 @@ import { RowProxyDelete } from './row-proxy-delete.interface';
  * @param parentService the service that will handle updating the parent row
  * @returns a proxy that will handle updating the row
  */
-export function rowProxy<
-  T extends SmartNgRXRowBase,
-  P extends SmartNgRXRowBase,
->(
+export function rowProxy<T extends SmartNgRXRowBase>(
   row: T,
-  service: ActionService<T>,
-  parentService: ActionService<P>,
+  service: ActionService,
+  parentService: ActionService,
 ): RowProxyDelete & T {
   return castTo<RowProxyDelete & T>(new RowProxy(row, service, parentService));
 }

--- a/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
@@ -231,8 +231,8 @@ describe('ArrayProxy', () => {
         };
         const parentProxy = new RowProxy(
           parent,
-          {} as unknown as ActionService<typeof parent>,
-          {} as unknown as ActionService<SmartNgRXRowBase>,
+          {} as unknown as ActionService,
+          {} as unknown as ActionService,
         );
         const newParent = castTo<{
           createNewParentFromParent(p: object, b: boolean): object;

--- a/libs/smart-ngrx/src/selector/array-proxy.class.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.ts
@@ -33,7 +33,7 @@ export class ArrayProxy<
   entityAdapter: EntityAdapter<C>;
   [isProxy] = true;
   rawArray: string[] = [];
-  childActionService: ActionService<C>;
+  childActionService: ActionService;
 
   /**
    * The constructor for the ArrayProxy class.
@@ -49,9 +49,7 @@ export class ArrayProxy<
     private childDefinition: ChildDefinition<P, C>,
   ) {
     const { childFeature, childEntity } = this.childDefinition;
-    this.childActionService = castTo<ActionService<C>>(
-      actionServiceRegistry(childFeature, childEntity),
-    );
+    this.childActionService = actionServiceRegistry(childFeature, childEntity);
     // needed primarily for adding items to the array
     const entityAdapter = entityDefinitionCache(
       childFeature,
@@ -142,8 +140,8 @@ export class ArrayProxy<
    * @returns actions, parentActions, and store
    */
   getServices(): {
-    service: ActionService<SmartNgRXRowBase>;
-    parentService: ActionService<SmartNgRXRowBase>;
+    service: ActionService;
+    parentService: ActionService;
   } {
     const { childFeature, childEntity, parentFeature, parentEntity } =
       this.childDefinition;

--- a/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/ensure-data-loaded.function.spec.ts
@@ -2,7 +2,6 @@
 import { createEntityAdapter } from '@ngrx/entity';
 
 import { ActionService } from '../actions/action.service';
-import { castTo } from '../common/cast-to.function';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import {
@@ -25,7 +24,7 @@ interface Row extends SmartNgRXRowBase {
 
 describe('ensureDataLoaded()', () => {
   let actionServiceLoadByIdsSpy: jest.SpyInstance;
-  let actionService: ActionService<Row>;
+  let actionService: ActionService;
   beforeEach(() => {
     createStore();
     entityDefinitionCache(feature, entity, {
@@ -34,9 +33,7 @@ describe('ensureDataLoaded()', () => {
     registerEntity(feature, entity, {
       markAndDeleteInit: { markDirtyFetchesNew: true },
     } as EntityAttributes);
-    actionService = castTo<ActionService<Row>>(
-      actionServiceRegistry(feature, entity),
-    );
+    actionService = actionServiceRegistry(feature, entity);
     actionServiceLoadByIdsSpy = jest.spyOn(actionService, 'loadByIds');
   });
   afterEach(() => {

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.ts
@@ -1,7 +1,5 @@
 import { EntityState } from '@ngrx/entity';
 
-import { ActionService } from '../actions/action.service';
-import { castTo } from '../common/cast-to.function';
 import { actionServiceRegistry } from '../registrations/action.service.registry';
 import { rowProxy } from '../row-proxy/row-proxy.function';
 import { RowProxyDelete } from '../row-proxy/row-proxy-delete.interface';
@@ -31,17 +29,13 @@ export function realOrMocked<
 ): RowProxyDelete & T {
   const { childFeature, childEntity, parentFeature, parentEntity } =
     childDefinition;
-  const service = castTo<ActionService<T>>(
-    actionServiceRegistry(childFeature, childEntity),
-  );
-  const parentService = castTo<ActionService<P>>(
-    actionServiceRegistry(parentFeature, parentEntity),
-  );
+  const service = actionServiceRegistry(childFeature, childEntity);
+  const parentService = actionServiceRegistry(parentFeature, parentEntity);
 
   const record = entityState.entities;
   let row = record[id];
   if (row === undefined) {
     row = { ...defaultObject, id };
   }
-  return rowProxy<T, P>(row, service, parentService);
+  return rowProxy<T>(row, service, parentService);
 }

--- a/libs/smart-ngrx/src/socket/delete-entity.function.ts
+++ b/libs/smart-ngrx/src/socket/delete-entity.function.ts
@@ -3,7 +3,6 @@ import { ParentInfo } from '../actions/parent-info.interface';
 import { removeIdFromParents } from '../actions/remove-id-from-parents.function';
 import { forNext } from '../common/for-next.function';
 import { childDefinitionRegistry } from '../registrations/child-definition.registry';
-import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 
 /**
  * Delete the feature/entity/ids from the store
@@ -13,7 +12,7 @@ import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
  * @param ids The ids of the rows that need to be deleted.
  */
 export function deleteEntity(feature: string, entity: string, ids: string[]) {
-  const actionService = new ActionService<SmartNgRXRowBase>(feature, entity);
+  const actionService = new ActionService(feature, entity);
   const childDefinitions = childDefinitionRegistry.getChildDefinition(
     feature,
     entity,

--- a/libs/smart-ngrx/src/socket/update-entity.function.ts
+++ b/libs/smart-ngrx/src/socket/update-entity.function.ts
@@ -19,7 +19,7 @@ export function updateEntity<T extends SmartNgRXRowBase>(
   entity: string,
   ids: string[],
 ): void {
-  const actionService = new ActionService<T>(feature, entity);
+  const actionService = new ActionService(feature, entity);
   // check for feature/entities the long way to avoid triggering warnings
   // there is also no good reason to memoize the result
   const selectEntities = (state: unknown) => {


### PR DESCRIPTION
# Issue Number: #497 

# Body

Eliminate more castTo by changing and remove generic types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified type declarations and removed unnecessary generic constraints across various functions and classes.
  - Removed dependency on `SmartNgRXRowBase` type in multiple files to enhance flexibility.

- **Bug Fixes**
  - Ensured type consistency and improved maintainability by directly referencing the `id` property instead of using type casting.

- **Tests**
  - Updated test cases to align with new type declarations and removed unnecessary type parameters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->