### PR TITLE
refactor: create public api

### DIFF
--- a/apps/demo/src/app/app.config.ts
+++ b/apps/demo/src/app/app.config.ts
@@ -13,7 +13,7 @@ import {
   StoreDevtoolsModule,
 } from '@ngrx/store-devtools';
 
-import { provideSmartNgRX } from '@smart/smart-ngrx/index';
+import { provideSmartNgRX } from '@smart/smart-ngrx';
 
 import { appRoutes } from './app.routes';
 import { DepartmentEffectsService } from './shared/department/department-effects.service';

--- a/apps/demo/src/app/app.routes.ts
+++ b/apps/demo/src/app/app.routes.ts
@@ -3,7 +3,7 @@ import { Routes } from '@angular/router';
 import { EffectsModule } from '@ngrx/effects';
 import { ActionReducerMap, StoreModule } from '@ngrx/store';
 
-import { provideSmartFeatureEntities } from '@smart/smart-ngrx/index';
+import { provideSmartFeatureEntities } from '@smart/smart-ngrx';
 
 import { watchLocations as watchNoDirtyLocations } from './routes/tree-no-dirty/store/current-location/current-location.effects';
 import { currentLocationNoDirtyReducer } from './routes/tree-no-dirty/store/current-location/current-location-no-dirty.reducer';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/department-children/no-dirty-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department-children/no-dirty-department-children-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
 import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department/department.selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeNoDirtyState } from '../tree-no-dirty.selectors';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/department/no-dirty-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department/no-dirty-departments-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Department } from '../../../../shared/department/department.interface';
 import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.actions.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.actions.ts
@@ -1,3 +1,3 @@
-import { actionFactory } from '@smart/smart-ngrx/actions/action.factory';
+import { actionFactory } from '@smart/smart-ngrx';
 
 export const locationActions = actionFactory('tree-no-dirty', 'locations');

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import {

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/no-dirty-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/no-dirty-locations-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/top/no-dirty-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/top/no-dirty-top-definition.const.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Top } from '../../../../shared/top/top.interface';
 import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-dirty/store/top/top.selector.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/top/top.selector.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectLocations, selectTopLocations } from './top.selector';
 

--- a/apps/demo/src/app/routes/tree-no-dirty/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/top/top.selector.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated.
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';

--- a/apps/demo/src/app/routes/tree-no-dirty/tree-no-dirty.component.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/tree-no-dirty.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { Location } from '../../shared/locations/location.interface';
 import { SharedModule } from '../../shared/shared.module';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department-children/no-refresh-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department-children/no-refresh-department-children-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
 import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department/department.selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeNoRefreshState } from '../tree-no-refresh.selectors';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department/no-refresh-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department/no-refresh-departments-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Department } from '../../../../shared/department/department.interface';
 import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.actions.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.actions.ts
@@ -1,3 +1,3 @@
-import { actionFactory } from '@smart/smart-ngrx/actions/action.factory';
+import { actionFactory } from '@smart/smart-ngrx';
 
 export const locationActions = actionFactory('tree-no-refresh', 'locations');

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import {

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/no-refresh-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/no-refresh-locations-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/top/no-refresh-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/top/no-refresh-top-definition.const.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Top } from '../../../../shared/top/top.interface';
 import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-refresh/store/top/top.selector.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/top/top.selector.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectLocations, selectTopLocations } from './top.selector';
 

--- a/apps/demo/src/app/routes/tree-no-refresh/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/top/top.selector.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated.
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';

--- a/apps/demo/src/app/routes/tree-no-refresh/tree-no-refresh.component.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/tree-no-refresh.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { Location } from '../../shared/locations/location.interface';
 import { SharedModule } from '../../shared/shared.module';

--- a/apps/demo/src/app/routes/tree-no-remove/store/department-children/no-remove-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department-children/no-remove-department-children-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
 import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-remove/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department/department.selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeNoRemoveState } from '../tree-no-remove.selectors';

--- a/apps/demo/src/app/routes/tree-no-remove/store/department/no-remove-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department/no-remove-departments-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Department } from '../../../../shared/department/department.interface';
 import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.actions.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.actions.ts
@@ -1,3 +1,3 @@
-import { actionFactory } from '@smart/smart-ngrx/actions/action.factory';
+import { actionFactory } from '@smart/smart-ngrx';
 
 export const locationActions = actionFactory('tree-no-remove', 'locations');

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import {

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/no-remove-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/no-remove-locations-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-remove/store/top/no-remove-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/top/no-remove-top-definition.const.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Top } from '../../../../shared/top/top.interface';
 import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';

--- a/apps/demo/src/app/routes/tree-no-remove/store/top/top.selector.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/top/top.selector.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectLocations, selectTopLocations } from './top.selector';
 

--- a/apps/demo/src/app/routes/tree-no-remove/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/top/top.selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';

--- a/apps/demo/src/app/routes/tree-no-remove/tree-no-remove.component.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/tree-no-remove.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable, of } from 'rxjs';
 
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { Location } from '../../shared/locations/location.interface';
 import { SharedModule } from '../../shared/shared.module';

--- a/apps/demo/src/app/routes/tree-standard/store/department-children/standard-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department-children/standard-department-children-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
 import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';

--- a/apps/demo/src/app/routes/tree-standard/store/department/department.selector.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department/department.selector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectDepartmentChildren } from '../department-children/department-child.selector';
 import { selectTreeStandardState } from '../tree-standard-state.selectors';

--- a/apps/demo/src/app/routes/tree-standard/store/department/standard-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department/standard-departments-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Department } from '../../../../shared/department/department.interface';
 import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.actions.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.actions.ts
@@ -1,3 +1,3 @@
-import { actionFactory } from '@smart/smart-ngrx/actions/action.factory';
+import { actionFactory } from '@smart/smart-ngrx';
 
 export const locationActions = actionFactory('tree-standard', 'locations');

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import {

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated because it is for different state for demo purposes
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { selectCurrentLocationId } from '../current-location/current-location.selector';
 import { selectDepartmentsChildren } from '../department/department.selector';

--- a/apps/demo/src/app/routes/tree-standard/store/locations/standard-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/standard-locations-definition.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';

--- a/apps/demo/src/app/routes/tree-standard/store/top/standard-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/top/standard-top-definition.const.ts
@@ -1,4 +1,4 @@
-import { SmartEntityDefinition } from '@smart/smart-ngrx/types/smart-entity-definition.interface';
+import { SmartEntityDefinition } from '@smart/smart-ngrx';
 
 import { Top } from '../../../../shared/top/top.interface';
 import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';

--- a/apps/demo/src/app/routes/tree-standard/store/top/top.selector.spec.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/top/top.selector.spec.ts
@@ -3,9 +3,7 @@
 import { MockStore } from '@ngrx/store/testing';
 import { firstValueFrom } from 'rxjs';
 
-import { store } from '@smart/smart-ngrx/selector/store.function';
-import { createStore } from '@smart/smart-ngrx/tests/functions/create-store.function';
-import { setState } from '@smart/smart-ngrx/tests/functions/set-state.function';
+import { createStore, setState, store } from '@smart/smart-ngrx';
 
 import { selectLocations, selectTopLocations } from './top.selector';
 

--- a/apps/demo/src/app/routes/tree-standard/store/top/top.selector.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/top/top.selector.ts
@@ -2,7 +2,7 @@
 // intentionally duplicated.
 import { createSelector } from '@ngrx/store';
 
-import { createSmartSelector } from '@smart/smart-ngrx/selector/create-smart-selector.function';
+import { createSmartSelector } from '@smart/smart-ngrx';
 
 import { Location } from '../../../../shared/locations/location.interface';
 import { selectLocationsDepartments } from '../locations/location.selectors';

--- a/apps/demo/src/app/shared/components/tree/common-source-node.interface.ts
+++ b/apps/demo/src/app/shared/components/tree/common-source-node.interface.ts
@@ -1,6 +1,8 @@
-import { RowProxyDelete } from '@smart/smart-ngrx/row-proxy/row-proxy-delete.interface';
-import { SmartArray } from '@smart/smart-ngrx/selector/smart-array.interface';
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import {
+  RowProxyDelete,
+  SmartArray,
+  SmartNgRXRowBase,
+} from '@smart/smart-ngrx';
 export interface CommonSourceNode extends SmartNgRXRowBase, RowProxyDelete {
   id: string;
   type?: string;

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.spec.ts
@@ -10,7 +10,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatTreeModule } from '@angular/material/tree';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
+import { castTo } from '@smart/smart-ngrx';
 
 import { Department } from '../../department/department.interface';
 import { CommonSourceNode } from './common-source-node.interface';

--- a/apps/demo/src/app/shared/components/tree/tree-component.service.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { assert } from '@smart/smart-ngrx/common/assert.function';
-import { forNext } from '@smart/smart-ngrx/common/for-next.function';
-import { SmartArray } from '@smart/smart-ngrx/selector/smart-array.interface';
+import { assert, forNext, SmartArray } from '@smart/smart-ngrx';
 
 import { DepartmentChild } from '../../department-children/department-child.interface';
 import { CommonSourceNode } from './common-source-node.interface';

--- a/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
+++ b/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { forkJoin, map, Observable, of } from 'rxjs';
 
-import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
+import { EffectService } from '@smart/smart-ngrx';
 
 import { DocsService } from '../docs/docs.service';
 import { FoldersService } from '../folders/folders.service';

--- a/apps/demo/src/app/shared/department-children/department-child.interface.ts
+++ b/apps/demo/src/app/shared/department-children/department-child.interface.ts
@@ -1,4 +1,4 @@
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 export interface DepartmentChild extends SmartNgRXRowBase {
   id: string;

--- a/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.spec.ts
+++ b/apps/demo/src/app/shared/department-children/load-by-ids-for-type.function.spec.ts
@@ -1,7 +1,7 @@
 import { map, Observable, of, timer } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
+import { castTo } from '@smart/smart-ngrx';
 
 import { List } from '../lists/list.interface';
 import { CommonService } from './common-service.class';

--- a/apps/demo/src/app/shared/department/children-transform.function.ts
+++ b/apps/demo/src/app/shared/department/children-transform.function.ts
@@ -1,4 +1,4 @@
-import { castTo } from '@smart/smart-ngrx/common/cast-to.function';
+import { castTo } from '@smart/smart-ngrx';
 
 import { Department } from './department.interface';
 

--- a/apps/demo/src/app/shared/department/department-effects.service.ts
+++ b/apps/demo/src/app/shared/department/department-effects.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map, Observable } from 'rxjs';
 
-import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
+import { EffectService } from '@smart/smart-ngrx';
 
 import { childrenTransform } from './children-transform.function';
 import { Department } from './department.interface';

--- a/apps/demo/src/app/shared/department/department.interface.ts
+++ b/apps/demo/src/app/shared/department/department.interface.ts
@@ -1,4 +1,4 @@
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { DepartmentChild } from '../department-children/department-child.interface';
 

--- a/apps/demo/src/app/shared/entities.ts
+++ b/apps/demo/src/app/shared/entities.ts
@@ -1,6 +1,6 @@
 import { EntityState } from '@ngrx/entity';
 
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { Department } from './department/department.interface';
 import { DepartmentChild } from './department-children/department-child.interface';

--- a/apps/demo/src/app/shared/locations/location-effects.service.ts
+++ b/apps/demo/src/app/shared/locations/location-effects.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 
-import { EffectService } from '@smart/smart-ngrx/effects/effect-service';
+import { EffectService } from '@smart/smart-ngrx';
 
 import { Location } from './location.interface';
 

--- a/apps/demo/src/app/shared/locations/location.interface.ts
+++ b/apps/demo/src/app/shared/locations/location.interface.ts
@@ -1,4 +1,4 @@
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { Department } from '../department/department.interface';
 

--- a/apps/demo/src/app/shared/socket.service.spec.ts
+++ b/apps/demo/src/app/shared/socket.service.spec.ts
@@ -1,17 +1,16 @@
-import * as handleSocketNotificationFunction from '@smart/smart-ngrx/socket/handle-socket-notification.function';
+import { handleSocketNotification as handleSocketNotificationSpy } from '@smart/smart-ngrx';
 
 import { SocketService } from './socket.service';
 
+jest.mock('@smart/smart-ngrx', () => ({
+  handleSocketNotification: jest.fn(),
+}));
+
 describe('SocketService', () => {
   let service: SocketService;
-  let handleSocketNotificationSpy: jest.SpyInstance;
 
   beforeAll(() => {
     service = new SocketService();
-    handleSocketNotificationSpy = jest.spyOn(
-      handleSocketNotificationFunction,
-      'handleSocketNotification',
-    );
   });
 
   describe('when table is docs', () => {

--- a/apps/demo/src/app/shared/socket.service.ts
+++ b/apps/demo/src/app/shared/socket.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { io, Socket } from 'socket.io-client';
 
-import { handleSocketNotification } from '@smart/smart-ngrx/socket/handle-socket-notification.function';
+import { handleSocketNotification } from '@smart/smart-ngrx';
 
 // We need to create this service using a factory so we can call init()
 // after the service is created so we don't provideIn: 'root'

--- a/apps/demo/src/app/shared/top/top-effects.service.ts
+++ b/apps/demo/src/app/shared/top/top-effects.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 
-import { EffectService } from '@smart/smart-ngrx/index';
+import { EffectService } from '@smart/smart-ngrx';
 
 import { Top } from './top.interface';
 

--- a/apps/demo/src/app/shared/top/top.interface.ts
+++ b/apps/demo/src/app/shared/top/top.interface.ts
@@ -1,4 +1,4 @@
-import { SmartNgRXRowBase } from '@smart/smart-ngrx/types/smart-ngrx-row-base.interface';
+import { SmartNgRXRowBase } from '@smart/smart-ngrx';
 
 import { Location } from '../locations/location.interface';
 

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
@@ -5,9 +5,13 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Observable, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-import { actionFactory, registerEntity, unregisterEntity } from '../..';
+import { actionFactory } from '../..';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
 import { entityDefinitionCache } from '../../registrations/entity-definition-cache.function';
+import {
+  registerEntity,
+  unregisterEntity,
+} from '../../registrations/register-entity.function';
 import { store as storeFunction } from '../../selector/store.function';
 import { EntityAttributes } from '../../types/entity-attributes.interface';
 import { SmartNgRXRowBase } from '../../types/smart-ngrx-row-base.interface';

--- a/libs/smart-ngrx/src/index.ts
+++ b/libs/smart-ngrx/src/index.ts
@@ -1,7 +1,23 @@
 export * from './actions/action.factory';
+export * from './common/assert.function';
+export * from './common/cast-to.function';
+export * from './common/for-next.function';
 export * from './effects/effect-service';
-export * from './effects/effects-factory.function';
 export * from './functions/provide-smart-feature-entities.function';
 export * from './functions/provide-smart-ngrx.function';
-export * from './reducers/reducer.factory';
-export * from './registrations/register-entity.function';
+export * from './row-proxy/row-proxy-delete.interface';
+export * from './selector/create-smart-selector.function';
+export * from './selector/smart-array.interface';
+
+// store.function is needed for testing
+export * from './selector/store.function';
+export * from './socket/handle-socket-notification.function';
+
+// testing utility functions (maybe move to their own lib?)
+export * from './tests/functions/clear-state.function';
+export * from './tests/functions/create-store.function';
+export * from './tests/functions/set-state.function';
+
+// types
+export * from './types/smart-entity-definition.interface';
+export * from './types/smart-ngrx-row-base.interface';

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
@@ -1,5 +1,8 @@
-import { registerEntity, unregisterEntity } from '../..';
 import { psi } from '../../common/theta.const';
+import {
+  registerEntity,
+  unregisterEntity,
+} from '../../registrations/register-entity.function';
 import { MarkAndDeleteInit } from '../../types/mark-and-delete-init.interface';
 import { registerGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
 import { markAndDeleteEntity } from './mark-and-delete-entity.function';

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.ts
@@ -1,4 +1,4 @@
-import { getEntityRegistry } from '../..';
+import { getEntityRegistry } from '../../registrations/register-entity.function';
 import { getGlobalMarkAndDeleteInit } from '../mark-and-delete-init';
 import { processMarkAndDelete } from './process-mark-and-delete.function';
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "nx affected:lint --parallel=5 --fix",
     "format": "nx format:write",
     "format:check": "nx format:check",
-    "test": "nx affected:test --parallel=5 --max-parallel=3",
+    "test": "nx affected:test --parallel=5 --max-parallel=5",
     "test:coverage": "pnpm test -- --coverage --skip-nx-cache",
     "dupcheck": "pnpm jscpd",
     "htmllint": "pnpm htmlhint \"apps/**/*.html\" \"libs/**/*.html\" --ignore=\"coverage/**/*\"",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,7 @@
     "paths": {
       "@ng-doc/generated": ["ng-doc/documentation/index.ts"],
       "@ng-doc/generated/*": ["ng-doc/documentation/*"],
-      "@smart/smart-ngrx/*": ["libs/smart-ngrx/src/*"]
+      "@smart/smart-ngrx": ["libs/smart-ngrx/src"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
# Issue Number: #486 

# Body

Created public API for SmartNgRX and refactored code to use the public API instead of deep imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Consolidated import statements from multiple specific paths to a single path within the `@smart/smart-ngrx` module across various files for improved maintainability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->