### PR TITLE
refactor: remove isDirty from default rows

### DIFF
--- a/apps/demo/src/app/routes/tree-no-dirty/store/department-children/no-dirty-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department-children/no-dirty-department-children-definition.ts
@@ -14,6 +14,5 @@ export const noDirtyDepartmentChildrenDefinition: SmartEntityDefinition<Departme
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-no-dirty/store/department/no-dirty-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department/no-dirty-departments-definition.ts
@@ -13,6 +13,5 @@ export const noDirtyDepartmentsDefinition: SmartEntityDefinition<Department> = {
     id,
     name: '',
     children: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
@@ -57,7 +57,6 @@ describe('Location Selectors', () => {
       id: '2',
       name: '',
       departments: [],
-      isDirty: false,
     };
 
     (store() as MockStore).overrideSelector(selectCurrentLocationId, '2');

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
@@ -31,7 +31,7 @@ describe('Location Selectors', () => {
     setState('tree-no-dirty2', 'currentLocation', '1');
     (store() as MockStore).overrideSelector(selectLocationsDepartments, {
       entities: {
-        1: { id: '1', name: location1string, departments: [], isDirty: false },
+        1: { id: '1', name: location1string, departments: [] },
       },
       ids: ['1'],
     });
@@ -43,7 +43,6 @@ describe('Location Selectors', () => {
       id: '1',
       name: location1string,
       departments: [],
-      isDirty: false,
     };
 
     const location = await firstValueFrom(

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.spec.ts
@@ -20,7 +20,6 @@ describe('Location Selectors', () => {
         id: '1',
         name: location1string,
         departments: [],
-        isDirty: false,
       },
     },
     ids: ['1'],

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/location.selectors.ts
@@ -38,7 +38,6 @@ export const selectCurrentLocation = createSelector(
         id,
         name: '',
         departments: [],
-        isDirty: false,
       }
     );
   },

--- a/apps/demo/src/app/routes/tree-no-dirty/store/locations/no-dirty-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/locations/no-dirty-locations-definition.ts
@@ -13,6 +13,5 @@ export const noDirtyLocationsDefinition: SmartEntityDefinition<Location> = {
     id,
     name: '',
     departments: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-no-dirty/store/top/no-dirty-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/top/no-dirty-top-definition.const.ts
@@ -13,6 +13,5 @@ export const noDirtyTopDefinition: SmartEntityDefinition<Top> = {
   defaultRow: (id) => ({
     id,
     locations: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department-children/no-refresh-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department-children/no-refresh-department-children-definition.ts
@@ -13,6 +13,5 @@ export const noRefreshDepartmentChildrenDefinition: SmartEntityDefinition<Depart
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department/no-refresh-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department/no-refresh-departments-definition.ts
@@ -13,6 +13,5 @@ export const noRefreshDepartmentsDefinition: SmartEntityDefinition<Department> =
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.spec.ts
@@ -58,7 +58,6 @@ describe('Location Selectors', () => {
       id: '2',
       name: '',
       departments: [],
-      isDirty: false,
     };
 
     (store() as MockStore).overrideSelector(selectCurrentLocationId, '2');

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.spec.ts
@@ -20,7 +20,6 @@ describe('Location Selectors', () => {
         id: '1',
         name: location1string,
         departments: [],
-        isDirty: false,
       },
     },
     ids: ['1'],
@@ -32,7 +31,7 @@ describe('Location Selectors', () => {
     setState('tree-no-refresh2', 'currentLocation', '1');
     (store() as MockStore).overrideSelector(selectLocationsDepartments, {
       entities: {
-        1: { id: '1', name: location1string, departments: [], isDirty: false },
+        1: { id: '1', name: location1string, departments: [] },
       },
       ids: ['1'],
     });
@@ -44,7 +43,6 @@ describe('Location Selectors', () => {
       id: '1',
       name: location1string,
       departments: [],
-      isDirty: false,
     };
 
     const location = await firstValueFrom(

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/location.selectors.ts
@@ -38,7 +38,6 @@ export const selectCurrentLocation = createSelector(
         id,
         name: '',
         departments: [],
-        isDirty: false,
       }
     );
   },

--- a/apps/demo/src/app/routes/tree-no-refresh/store/locations/no-refresh-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/locations/no-refresh-locations-definition.ts
@@ -15,6 +15,5 @@ export const noRefreshLocationsDefinition: SmartEntityDefinition<Location> = {
     id,
     name: '',
     departments: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-no-refresh/store/top/no-refresh-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/top/no-refresh-top-definition.const.ts
@@ -15,6 +15,5 @@ export const noRefreshTopDefinition: SmartEntityDefinition<Top> = {
   defaultRow: (id) => ({
     id,
     locations: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-no-remove/store/department-children/no-remove-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department-children/no-remove-department-children-definition.ts
@@ -15,6 +15,5 @@ export const noRemoveDepartmentChildrenDefinition: SmartEntityDefinition<Departm
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-no-remove/store/department/no-remove-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department/no-remove-departments-definition.ts
@@ -15,6 +15,5 @@ export const noRemoveDepartmentsDefinition: SmartEntityDefinition<Department> =
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.spec.ts
@@ -58,7 +58,6 @@ describe('Location Selectors', () => {
       id: '2',
       name: '',
       departments: [],
-      isDirty: false,
     };
 
     (store() as MockStore).overrideSelector(selectCurrentLocationId, '2');

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.spec.ts
@@ -20,7 +20,6 @@ describe('Location Selectors', () => {
         id: '1',
         name: location1string,
         departments: [],
-        isDirty: false,
       },
     },
     ids: ['1'],
@@ -32,7 +31,7 @@ describe('Location Selectors', () => {
     setState('tree-no-remove2', 'currentLocation', '1');
     (store() as MockStore).overrideSelector(selectLocationsDepartments, {
       entities: {
-        1: { id: '1', name: location1string, departments: [], isDirty: false },
+        1: { id: '1', name: location1string, departments: [] },
       },
       ids: ['1'],
     });
@@ -44,7 +43,6 @@ describe('Location Selectors', () => {
       id: '1',
       name: location1string,
       departments: [],
-      isDirty: false,
     };
 
     const location = await firstValueFrom(

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/location.selectors.ts
@@ -38,7 +38,6 @@ export const selectCurrentLocation = createSelector(
         id,
         name: '',
         departments: [],
-        isDirty: false,
       }
     );
   },

--- a/apps/demo/src/app/routes/tree-no-remove/store/locations/no-remove-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/locations/no-remove-locations-definition.ts
@@ -14,6 +14,5 @@ export const noRemoveLocationsDefinition: SmartEntityDefinition<Location> = {
     id,
     name: '',
     departments: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-no-remove/store/top/no-remove-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/top/no-remove-top-definition.const.ts
@@ -14,6 +14,5 @@ export const noRemoveTopDefinition: SmartEntityDefinition<Top> = {
   defaultRow: (id) => ({
     id,
     locations: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-standard/store/department-children/standard-department-children-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department-children/standard-department-children-definition.ts
@@ -11,6 +11,5 @@ export const standardDepartmentChildrenDefinition: SmartEntityDefinition<Departm
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-standard/store/department/standard-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department/standard-departments-definition.ts
@@ -11,6 +11,5 @@ export const standardDepartmentsDefinition: SmartEntityDefinition<Department> =
       id,
       name: '',
       children: [],
-      isDirty: false,
     }),
   };

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.spec.ts
@@ -20,7 +20,6 @@ describe('Location Selectors', () => {
         id: '1',
         name: location1string,
         departments: [],
-        isDirty: false,
       },
     },
     ids: ['1'],
@@ -32,7 +31,7 @@ describe('Location Selectors', () => {
     setState('tree-standard2', 'currentLocation', '1');
     (store() as MockStore).overrideSelector(selectLocationsDepartments, {
       entities: {
-        1: { id: '1', name: location1string, departments: [], isDirty: false },
+        1: { id: '1', name: location1string, departments: [] },
       },
       ids: ['1'],
     });
@@ -44,7 +43,6 @@ describe('Location Selectors', () => {
       id: '1',
       name: location1string,
       departments: [],
-      isDirty: false,
     };
 
     const location = await firstValueFrom(

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.spec.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.spec.ts
@@ -58,7 +58,6 @@ describe('Location Selectors', () => {
       id: '2',
       name: '',
       departments: [],
-      isDirty: false,
     };
 
     (store() as MockStore).overrideSelector(selectCurrentLocationId, '2');

--- a/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/location.selectors.ts
@@ -38,7 +38,6 @@ export const selectCurrentLocation = createSelector(
         id,
         name: '',
         departments: [],
-        isDirty: false,
       }
     );
   },

--- a/apps/demo/src/app/routes/tree-standard/store/locations/standard-locations-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/locations/standard-locations-definition.ts
@@ -10,6 +10,5 @@ export const standardLocationsDefinition: SmartEntityDefinition<Location> = {
     id,
     name: '',
     departments: [],
-    isDirty: false,
   }),
 };

--- a/apps/demo/src/app/routes/tree-standard/store/top/standard-top-definition.const.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/top/standard-top-definition.const.ts
@@ -10,6 +10,5 @@ export const standardTopDefinition: SmartEntityDefinition<Top> = {
   defaultRow: (id) => ({
     id,
     locations: [],
-    isDirty: false,
   }),
 };

--- a/libs/smart-ngrx/src/actions/action.service.spec.ts
+++ b/libs/smart-ngrx/src/actions/action.service.spec.ts
@@ -48,7 +48,7 @@ describe('ActionService', () => {
     entityDefinitionCache(feature, entity, {
       entityName: entity,
       effectServiceToken: null, // serviceToken isn't needed for these tests
-      defaultRow: (id: string) => ({ id, name: '', foo: '', isDirty: false }),
+      defaultRow: (id: string) => ({ id, name: '', foo: '' }),
       entityAdapter: createEntityAdapter(),
     } as unknown as SmartEntityDefinition<Row>);
     service = castTo<PublicMarkDirtyWithEntities>(
@@ -65,7 +65,7 @@ describe('ActionService', () => {
         storeDispatchSpy = jest.spyOn(store, 'dispatch');
         service.markDirtyWithEntities(
           {
-            '2': { id: '2', name: 'name', isDirty: false },
+            '2': { id: '2', name: 'name' },
           },
           ['1'],
         );
@@ -84,7 +84,7 @@ describe('ActionService', () => {
           storeDispatchSpy = jest.spyOn(store, 'dispatch');
           service.markDirtyWithEntities(
             {
-              '2': { id: '2', name: 'name', isDirty: false },
+              '2': { id: '2', name: 'name' },
             },
             ['2'],
           );
@@ -109,7 +109,7 @@ describe('ActionService', () => {
           storeDispatchSpy = jest.spyOn(store, 'dispatch');
           service.markDirtyWithEntities(
             {
-              '2': { id: '2', name: 'name', isDirty: false, isEditing: true },
+              '2': { id: '2', name: 'name', isEditing: true },
             },
             ['2'],
           );
@@ -128,10 +128,9 @@ describe('ActionService', () => {
     describe('when the id is not in the entities', () => {
       beforeEach(() => {
         storeDispatchSpy = jest.spyOn(store, 'dispatch');
-        service.garbageCollectWithEntities(
-          { '2': { id: '2', name: 'name', isDirty: false } },
-          ['1'],
-        );
+        service.garbageCollectWithEntities({ '2': { id: '2', name: 'name' } }, [
+          '1',
+        ]);
       });
       it('should dispatch an action but there should not be any changes', () => {
         expect(storeDispatchSpy).not.toHaveBeenCalled();
@@ -142,7 +141,7 @@ describe('ActionService', () => {
         beforeEach(() => {
           storeDispatchSpy = jest.spyOn(store, 'dispatch');
           service.garbageCollectWithEntities(
-            { '2': { id: '2', name: 'name', isDirty: false } },
+            { '2': { id: '2', name: 'name' } },
             ['2'],
           );
         });
@@ -154,7 +153,7 @@ describe('ActionService', () => {
         beforeEach(() => {
           storeDispatchSpy = jest.spyOn(store, 'dispatch');
           service.garbageCollectWithEntities(
-            { '2': { id: '2', name: 'name', isDirty: false, isEditing: true } },
+            { '2': { id: '2', name: 'name', isEditing: true } },
             ['2'],
           );
         });
@@ -168,7 +167,7 @@ describe('ActionService', () => {
     beforeEach(() => {
       setState(feature, entity, {
         ids: ['1'],
-        entities: { '1': { id: '1', name: 'name', isDirty: false } },
+        entities: { '1': { id: '1', name: 'name' } },
       });
     });
     let markDirtyWithEntitiesSpy: jest.SpyInstance;

--- a/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
+++ b/libs/smart-ngrx/src/actions/remove-id-from-feature-parents.function.spec.ts
@@ -21,15 +21,11 @@ describe('removeIdFromParents()', () => {
       '1': {
         id: '1',
         name: 'name',
-        isDirty: false,
-        isEditing: false,
         children: ['a', 'b', 'c'],
       },
       '2': {
         id: '2',
         name: 'name',
-        isDirty: false,
-        isEditing: false,
         children: ['a', 'd', 'e'],
       },
     };

--- a/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/update-effect.function.spec.ts
@@ -26,7 +26,6 @@ interface Row extends SmartNgRXRowBase {
   id: string;
   name: string;
   foo: string;
-  isDirty: boolean;
 }
 class TestService extends EffectService<Row> {
   override loadByIds(_: string[]): Observable<Row[]> {
@@ -57,7 +56,7 @@ describe('update-effect.function.ts', () => {
   entityDefinitionCache(feature, entity, {
     entityName: entity,
     effectServiceToken: serviceToken,
-    defaultRow: (id: string) => ({ id, name: '', foo: '', isDirty: false }),
+    defaultRow: (id: string) => ({ id, name: '', foo: '' }),
     entityAdapter: createEntityAdapter(),
   });
   const testService = new TestService();
@@ -89,8 +88,8 @@ describe('update-effect.function.ts', () => {
       testScheduler.run(({ cold, expectObservable, flush }) => {
         const input = cold('-a', {
           a: actions.update({
-            old: { row: { id: '1', name: 'foo', foo: 'bar', isDirty: false } },
-            new: { row: { id: '1', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '1', name: 'foo', foo: 'bar' } },
+            new: { row: { id: '1', name: 'foo2', foo: 'bar' } },
           }),
         });
         const output = cold('--a', {
@@ -100,7 +99,7 @@ describe('update-effect.function.ts', () => {
         flush();
         expect(serviceSpy).toHaveBeenCalledTimes(1);
         expect(actionServiceLoadByIdsSuccessSpy).toHaveBeenCalledWith([
-          { id: '1', name: 'foo2', foo: 'bar', isDirty: false },
+          { id: '1', name: 'foo2', foo: 'bar' },
         ]);
       });
     });
@@ -110,13 +109,13 @@ describe('update-effect.function.ts', () => {
       testScheduler.run(({ cold, expectObservable, flush }) => {
         const input = cold('-ab', {
           a: actions.update({
-            old: { row: { id: '1', name: 'foo', foo: 'bar', isDirty: false } },
-            new: { row: { id: '1', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '1', name: 'foo', foo: 'bar' } },
+            new: { row: { id: '1', name: 'foo2', foo: 'bar' } },
           }),
           b: actions.update({
-            old: { row: { id: '1', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '1', name: 'foo2', foo: 'bar' } },
             new: {
-              row: { id: '1', name: 'foo2', foo: 'bar2', isDirty: false },
+              row: { id: '1', name: 'foo2', foo: 'bar2' },
             },
           }),
         });
@@ -127,7 +126,7 @@ describe('update-effect.function.ts', () => {
         flush();
         expect(serviceSpy).toHaveBeenCalledTimes(1);
         expect(actionServiceLoadByIdsSuccessSpy).toHaveBeenCalledWith([
-          { id: '1', name: 'foo2', foo: 'bar2', isDirty: false },
+          { id: '1', name: 'foo2', foo: 'bar2' },
         ]);
       });
     });
@@ -137,13 +136,13 @@ describe('update-effect.function.ts', () => {
       testScheduler.run(({ cold, expectObservable, flush }) => {
         const input = cold('-ab', {
           a: actions.update({
-            old: { row: { id: '1', name: 'foo', foo: 'bar', isDirty: false } },
-            new: { row: { id: '1', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '1', name: 'foo', foo: 'bar' } },
+            new: { row: { id: '1', name: 'foo2', foo: 'bar' } },
           }),
           b: actions.update({
-            old: { row: { id: '2', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '2', name: 'foo2', foo: 'bar' } },
             new: {
-              row: { id: '2', name: 'foo2', foo: 'bar2', isDirty: false },
+              row: { id: '2', name: 'foo2', foo: 'bar2' },
             },
           }),
         });
@@ -155,10 +154,10 @@ describe('update-effect.function.ts', () => {
         flush();
         expect(serviceSpy).toHaveBeenCalledTimes(2);
         expect(actionServiceLoadByIdsSuccessSpy).toHaveBeenCalledWith([
-          { id: '1', name: 'foo2', foo: 'bar', isDirty: false },
+          { id: '1', name: 'foo2', foo: 'bar' },
         ]);
         expect(actionServiceLoadByIdsSuccessSpy).toHaveBeenCalledWith([
-          { id: '2', name: 'foo2', foo: 'bar2', isDirty: false },
+          { id: '2', name: 'foo2', foo: 'bar2' },
         ]);
       });
     });
@@ -168,27 +167,27 @@ describe('update-effect.function.ts', () => {
       testScheduler.run(({ cold, expectObservable, flush }) => {
         const input = cold('-abcd', {
           a: actions.update({
-            old: { row: { id: '1', name: 'foo', foo: 'bar', isDirty: false } },
-            new: { row: { id: '1', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '1', name: 'foo', foo: 'bar' } },
+            new: { row: { id: '1', name: 'foo2', foo: 'bar' } },
           }),
           b: actions.update({
-            old: { row: { id: '2', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '2', name: 'foo2', foo: 'bar' } },
             new: {
-              row: { id: '2', name: 'foo2a', foo: 'bar2', isDirty: false },
+              row: { id: '2', name: 'foo2a', foo: 'bar2' },
             },
           }),
           c: actions.update({
-            old: { row: { id: '1', name: 'foo2', foo: 'bar', isDirty: false } },
+            old: { row: { id: '1', name: 'foo2', foo: 'bar' } },
             new: {
-              row: { id: '1', name: 'foo2', foo: 'bar2', isDirty: false },
+              row: { id: '1', name: 'foo2', foo: 'bar2' },
             },
           }),
           d: actions.update({
             old: {
-              row: { id: '2', name: 'foo2a', foo: 'bar2', isDirty: false },
+              row: { id: '2', name: 'foo2a', foo: 'bar2' },
             },
             new: {
-              row: { id: '2', name: 'foo2a', foo: 'bar2a', isDirty: false },
+              row: { id: '2', name: 'foo2a', foo: 'bar2a' },
             },
           }),
         });
@@ -200,10 +199,10 @@ describe('update-effect.function.ts', () => {
         flush();
         expect(serviceSpy).toHaveBeenCalledTimes(2);
         expect(actionServiceLoadByIdsSuccessSpy).toHaveBeenCalledWith([
-          { id: '1', name: 'foo2', foo: 'bar2', isDirty: false },
+          { id: '1', name: 'foo2', foo: 'bar2' },
         ]);
         expect(actionServiceLoadByIdsSuccessSpy).toHaveBeenCalledWith([
-          { id: '2', name: 'foo2a', foo: 'bar2a', isDirty: false },
+          { id: '2', name: 'foo2a', foo: 'bar2a' },
         ]);
       });
     });

--- a/libs/smart-ngrx/src/functions/delayed-register-entity.function.spec.ts
+++ b/libs/smart-ngrx/src/functions/delayed-register-entity.function.spec.ts
@@ -15,7 +15,7 @@ describe('delayedRegisterEntity', () => {
         entityName: 'entityName',
         effectServiceToken: new InjectionToken<string>('fooBar'),
         defaultRow(id: string) {
-          return { id, isDirty: false };
+          return { id };
         },
       });
       expect(returnValue).toBe(true);

--- a/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
+++ b/libs/smart-ngrx/src/mark-and-delete/mark-and-delete-effect/mark-and-delete-entity.function.spec.ts
@@ -33,7 +33,6 @@ describe('markAndDeleteEntity', () => {
         defaultRow: (id) => {
           return {
             id,
-            isDirty: false,
           };
         },
       });
@@ -66,7 +65,6 @@ describe('markAndDeleteEntity', () => {
         defaultRow: (id) => {
           return {
             id,
-            isDirty: false,
           };
         },
       });
@@ -93,7 +91,6 @@ describe('markAndDeleteEntity', () => {
         defaultRow: (id) => {
           return {
             id,
-            isDirty: false,
           };
         },
       });
@@ -120,7 +117,6 @@ describe('markAndDeleteEntity', () => {
         defaultRow: (id) => {
           return {
             id,
-            isDirty: false,
           };
         },
       });
@@ -147,7 +143,6 @@ describe('markAndDeleteEntity', () => {
         defaultRow: (id) => {
           return {
             id,
-            isDirty: false,
           };
         },
       });

--- a/libs/smart-ngrx/src/reducers/default-rows.function.spec.ts
+++ b/libs/smart-ngrx/src/reducers/default-rows.function.spec.ts
@@ -3,7 +3,7 @@ import { EntityState } from '@ngrx/entity';
 import { defaultRows } from './default-rows.function';
 
 describe('default-rows.function.ts', () => {
-  const defaultRow = (id: string) => ({ id, isDirty: false });
+  const defaultRow = (id: string) => ({ id });
   let returnedRows = [];
   describe('when I pass an ID that is not in state', () => {
     it('should return a row with the id', () => {
@@ -13,18 +13,16 @@ describe('default-rows.function.ts', () => {
         entities: {},
       };
       returnedRows = defaultRows(ids, state.entities, defaultRow);
-      expect(returnedRows).toEqual([
-        { id: '1', isDirty: false, isLoading: true },
-      ]);
+      expect(returnedRows).toEqual([{ id: '1', isLoading: true }]);
     });
   });
   describe('when I pass an ID that is in state', () => {
     it('should return an empty array', () => {
       const ids = ['1'];
-      const state: EntityState<{ id: string; isDirty: boolean }> = {
+      const state: EntityState<{ id: string }> = {
         ids: ['1'],
         entities: {
-          '1': { id: '1', isDirty: false },
+          '1': { id: '1' },
         },
       };
       returnedRows = defaultRows(ids, state.entities, defaultRow);
@@ -34,19 +32,19 @@ describe('default-rows.function.ts', () => {
   describe('when I pass a mixture of IDs in and out of state', () => {
     it('should return an empty array', () => {
       const ids = ['1', '2', '3', '4', '5', '6'];
-      const state: EntityState<{ id: string; isDirty: boolean }> = {
+      const state: EntityState<{ id: string }> = {
         ids: ['1', '3', '4'],
         entities: {
-          '1': { id: '1', isDirty: false },
-          '3': { id: '3', isDirty: false },
-          '4': { id: '4', isDirty: false },
+          '1': { id: '1' },
+          '3': { id: '3' },
+          '4': { id: '4' },
         },
       };
       returnedRows = defaultRows(ids, state.entities, defaultRow);
       expect(returnedRows).toEqual([
-        { id: '2', isDirty: false, isLoading: true },
-        { id: '5', isDirty: false, isLoading: true },
-        { id: '6', isDirty: false, isLoading: true },
+        { id: '2', isLoading: true },
+        { id: '5', isLoading: true },
+        { id: '6', isLoading: true },
       ]);
     });
   });
@@ -55,12 +53,12 @@ describe('default-rows.function.ts', () => {
       const ids = ['1', '2', '3', '4', '5', '6'];
       returnedRows = defaultRows(ids, undefined, defaultRow);
       expect(returnedRows).toEqual([
-        { id: '1', isDirty: false, isLoading: true },
-        { id: '2', isDirty: false, isLoading: true },
-        { id: '3', isDirty: false, isLoading: true },
-        { id: '4', isDirty: false, isLoading: true },
-        { id: '5', isDirty: false, isLoading: true },
-        { id: '6', isDirty: false, isLoading: true },
+        { id: '1', isLoading: true },
+        { id: '2', isLoading: true },
+        { id: '3', isLoading: true },
+        { id: '4', isLoading: true },
+        { id: '5', isLoading: true },
+        { id: '6', isLoading: true },
       ]);
     });
   });

--- a/libs/smart-ngrx/src/registrations/entity-definition-cache.function.spec.ts
+++ b/libs/smart-ngrx/src/registrations/entity-definition-cache.function.spec.ts
@@ -24,9 +24,6 @@ describe('provideSmartFeatureEntities', () => {
     effectServiceToken: null as unknown as EffectServiceToken<SmartNgRXRowBase>,
     defaultRow: () => ({
       id: '1',
-      isDirty: false,
-      isLoading: false,
-      isEditing: false,
     }),
   };
   beforeEach(() => {

--- a/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
+++ b/libs/smart-ngrx/src/selector/array-proxy.class.spec.ts
@@ -198,7 +198,6 @@ describe('ArrayProxy', () => {
           id: '1',
           name: 'foo',
           isEditing: false,
-          isDirty: false,
         };
         const newParent = castTo<{
           createNewParentFromParent(p: object, b: boolean): object;
@@ -207,7 +206,6 @@ describe('ArrayProxy', () => {
           id: '1',
           name: 'foo',
           isEditing: true,
-          isDirty: false,
         });
       });
     });
@@ -227,7 +225,6 @@ describe('ArrayProxy', () => {
           id: '1',
           name: 'foo',
           isEditing: false,
-          isDirty: false,
         };
         const parentProxy = new RowProxy(
           parent,
@@ -241,7 +238,6 @@ describe('ArrayProxy', () => {
           id: '1',
           name: 'foo',
           isEditing: true,
-          isDirty: false,
         });
       });
     });

--- a/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/real-or-mocked.function.spec.ts
@@ -20,7 +20,6 @@ const real = {
     department1: {
       id: 'department1',
       name: 'Department 1',
-      isDirty: false,
     },
   },
 };
@@ -28,7 +27,6 @@ const real = {
 const defaultObject = {
   id: 'department2',
   name: 'to be fetched',
-  isDirty: false,
 };
 
 describe('realOrMocked', () => {
@@ -39,18 +37,18 @@ describe('realOrMocked', () => {
     parentEntity: 'parentEntity',
   } as unknown as ChildDefinition<
     SmartNgRXRowBase,
-    { id: string; name: string; isDirty: boolean }
+    { id: string; name: string }
   >;
   entityDefinitionCache('feature', 'entity', {
     entityName: 'entity',
     entityAdapter: createEntityAdapter(),
-    defaultRow: (id: string) => ({ isDirty: false, name: '', id }),
+    defaultRow: (id: string) => ({ name: '', id }),
     effectServiceToken: null,
   } as unknown as SmartEntityDefinition<typeof defaultObject>);
   entityDefinitionCache('parentFeature', 'parentEntity', {
     entityName: 'parentEntity',
     entityAdapter: createEntityAdapter(),
-    defaultRow: (id: string) => ({ isDirty: false, name: '', id }),
+    defaultRow: (id: string) => ({ name: '', id }),
     effectServiceToken: null,
   } as unknown as SmartEntityDefinition<typeof defaultObject>);
   beforeEach(() => {
@@ -76,7 +74,6 @@ describe('realOrMocked', () => {
     expect(JSON.parse(JSON.stringify(r))).toEqual({
       id: 'department1',
       name: 'Department 1',
-      isDirty: false,
     });
   });
 
@@ -86,7 +83,6 @@ describe('realOrMocked', () => {
     expect(JSON.parse(JSON.stringify(r))).toEqual({
       id: 'department2',
       name: 'to be fetched',
-      isDirty: false,
     });
   });
 });


### PR DESCRIPTION
# Issue Number: #512 

# Body

remove isDirty from default rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the `isDirty` property from various objects and test cases across the application.

These changes streamline the data models and test cases, reducing unnecessary properties and simplifying the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->