### PR TITLE
fix:change compilationMode to partial for lib prod build

### DIFF
--- a/libs/smart-ngrx/tsconfig.lib.prod.json
+++ b/libs/smart-ngrx/tsconfig.lib.prod.json
@@ -3,5 +3,7 @@
   "compilerOptions": {
     "declarationMap": false
   },
-  "angularCompilerOptions": {}
+  "angularCompilerOptions": {
+    "compilationMode": "partial"
+  }
 }


### PR DESCRIPTION
# Issue Number: #521 

# Body

libs need to be in compilationMode: partial to publish to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Angular compiler options for improved build performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->