### PR TITLE
refactor(smart-ngrx): remove the distinction between virtual and eager arrays

### DIFF
--- a/apps/demo/src/app/routes/tree-no-dirty/store/department/no-dirty-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-dirty/store/department/no-dirty-departments-definition.ts
@@ -10,9 +10,6 @@ export const noDirtyDepartmentsDefinition: SmartEntityDefinition<Department> = {
   markAndDelete: {
     markDirtyTime: -1,
   },
-  children: {
-    virtualChildren: 'virtual',
-  },
   defaultRow: (id) => ({
     id,
     name: '',

--- a/apps/demo/src/app/routes/tree-no-refresh/store/department/no-refresh-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-refresh/store/department/no-refresh-departments-definition.ts
@@ -10,9 +10,6 @@ export const noRefreshDepartmentsDefinition: SmartEntityDefinition<Department> =
     entityName: 'departments',
     effectServiceToken: departmentEffectsServiceToken,
     markAndDelete,
-    children: {
-      virtualChildren: 'virtual',
-    },
     defaultRow: (id) => ({
       id,
       name: '',

--- a/apps/demo/src/app/routes/tree-no-remove/store/department/no-remove-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-no-remove/store/department/no-remove-departments-definition.ts
@@ -12,9 +12,6 @@ export const noRemoveDepartmentsDefinition: SmartEntityDefinition<Department> =
       markDirtyTime: 2 * 60 * 1000,
       removeTime: 0,
     },
-    children: {
-      virtualChildren: 'virtual',
-    },
     defaultRow: (id) => ({
       id,
       name: '',

--- a/apps/demo/src/app/routes/tree-standard/store/department/standard-departments-definition.ts
+++ b/apps/demo/src/app/routes/tree-standard/store/department/standard-departments-definition.ts
@@ -8,9 +8,6 @@ export const standardDepartmentsDefinition: SmartEntityDefinition<Department> =
   {
     entityName: 'departments',
     effectServiceToken: departmentEffectsServiceToken,
-    children: {
-      virtualChildren: 'virtual',
-    },
     defaultRow: (id) => ({
       id,
       name: '',

--- a/libs/smart-ngrx/src/selector/convert-children-to-virtual-array.function.spec.ts
+++ b/libs/smart-ngrx/src/selector/convert-children-to-virtual-array.function.spec.ts
@@ -1,7 +1,6 @@
 import { EntityState } from '@ngrx/entity';
 
 import { ActionGroup } from '../actions/action-group.interface';
-import { ChildType } from '../types/child-type.type';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { VirtualArrayContents } from '../types/virtual-array-contents.interface';
 import { convertChildrenToVirtualArray } from './convert-children-to-virtual-array.function';
@@ -12,13 +11,11 @@ describe('convertChildrenToVirtualArray', () => {
     field: VirtualArray<Parent> | VirtualArrayContents;
   }
 
-  let children: Partial<Record<keyof Parent, ChildType>>;
   let parentFieldName: keyof Parent;
   let parentEntity: EntityState<Parent>;
   let parentAction: ActionGroup;
 
   beforeEach(() => {
-    children = { field: 'virtual' };
     parentFieldName = 'field';
     parentEntity = {
       ids: ['1'],
@@ -30,26 +27,18 @@ describe('convertChildrenToVirtualArray', () => {
   });
 
   it('should convert field to VirtualArray when children[parentFieldName] is "virtual"', () => {
-    convertChildrenToVirtualArray(
-      children,
-      parentFieldName,
-      parentEntity,
-      parentAction,
-    );
+    convertChildrenToVirtualArray(parentFieldName, parentEntity, parentAction);
 
     const row = parentEntity.entities['1'];
     expect(row?.field).toBeInstanceOf(VirtualArray);
   });
 
-  it('should not convert field to VirtualArray when children[parentFieldName] is not "virtual"', () => {
-    children = { field: 'fixed' };
-
-    convertChildrenToVirtualArray(
-      children,
-      parentFieldName,
-      parentEntity,
-      parentAction,
-    );
+  it('should not convert field to VirtualArray when row[childField] is an Array', () => {
+    const field = parentEntity.entities['1'];
+    if (field) {
+      field.field = [] as unknown as VirtualArrayContents;
+    }
+    convertChildrenToVirtualArray(parentFieldName, parentEntity, parentAction);
 
     const row = parentEntity.entities['1'];
     expect(row?.field).not.toBeInstanceOf(VirtualArray);

--- a/libs/smart-ngrx/src/selector/convert-children-to-virtual-array.function.ts
+++ b/libs/smart-ngrx/src/selector/convert-children-to-virtual-array.function.ts
@@ -1,8 +1,6 @@
 import { EntityState } from '@ngrx/entity';
 
 import { ActionGroup } from '../actions/action-group.interface';
-import { forNext } from '../common/for-next.function';
-import { ChildType } from '../types/child-type.type';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { VirtualArrayContents } from '../types/virtual-array-contents.interface';
 import { VirtualArray } from './virtual-array.class';
@@ -10,7 +8,6 @@ import { VirtualArray } from './virtual-array.class';
 /**
  * Converts the child field to a virtual array
  *
- * @param children holds the type of child we are dealing with
  * @param parentFieldName the name of the field in the row to convert
  * @param parentEntity the entity data we are dealing with
  * @param parentAction the action group for the row
@@ -19,25 +16,26 @@ export function convertChildrenToVirtualArray<
   P extends SmartNgRXRowBase,
   C extends SmartNgRXRowBase,
 >(
-  children: Partial<Record<keyof P, ChildType>> | undefined,
   parentFieldName: keyof P,
   parentEntity: EntityState<P>,
   parentAction: ActionGroup,
 ): void {
-  /* istanbul ignore next -- this is going away soon */
-  if (children?.[parentFieldName] === 'virtual') {
-    // Because NgRX freeze may be turned on
-    forNext(parentEntity.ids as string[], (id) => {
-      let row = parentEntity.entities[id]!;
-      row = { ...row };
-      const arrayContent = row[parentFieldName] as VirtualArrayContents;
-      row[parentFieldName] = new VirtualArray<P, C>(
-        arrayContent,
-        parentAction,
-        id,
-        parentFieldName as string,
-      ) as P[keyof P];
-      parentEntity.entities[id] = row;
-    });
+  const length = parentEntity.ids.length;
+  for (let i = 0; i < length; i++) {
+    const id = parentEntity.ids[i] as string;
+    let row = parentEntity.entities[id]!;
+    row = { ...row };
+    const arrayContent = row[parentFieldName] as VirtualArrayContents;
+    // if it is an array, we can't convert it to a virtual array.
+    if (Array.isArray(arrayContent)) {
+      return;
+    }
+    row[parentFieldName] = new VirtualArray<P, C>(
+      arrayContent,
+      parentAction,
+      id,
+      parentFieldName as string,
+    ) as P[keyof P];
+    parentEntity.entities[id] = row;
   }
 }

--- a/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
+++ b/libs/smart-ngrx/src/selector/create-inner-smart-selector.function.ts
@@ -4,9 +4,7 @@ import { createSelector, MemoizedSelector } from '@ngrx/store';
 import { actionFactory } from '../actions/action.factory';
 import { castTo } from '../common/cast-to.function';
 import { childDefinitionRegistry } from '../registrations/child-definition.registry';
-import { entityDefinitionCache } from '../registrations/entity-definition-cache.function';
 import { ChildDefinition } from '../types/child-definition.interface';
-import { ChildType } from '../types/child-type.type';
 import { SmartNgRXRowBase } from '../types/smart-ngrx-row-base.interface';
 import { convertChildrenToArrayProxy } from './convert-children-to-array-proxy.function';
 import { convertChildrenToVirtualArray } from './convert-children-to-virtual-array.function';
@@ -55,15 +53,12 @@ export function createInnerSmartSelector<
   const parentAction = actionFactory(parentFeature, parentEntity);
   return castTo<MemoizedSelector<object, EntityState<P>>>(
     createSelector(parentSelector, childSelector, (parent, child) => {
-      const children = entityDefinitionCache(parentFeature, parentEntity)
-        .children as Partial<Record<keyof P, ChildType>> | undefined;
       const newParentEntity: EntityState<P> = {
         ids: [...parent.ids] as number[] | string[],
         entities: { ...parent.entities },
       };
 
       convertChildrenToVirtualArray(
-        children,
         parentFieldName,
         newParentEntity,
         parentAction,

--- a/libs/smart-ngrx/src/types/child-type.type.ts
+++ b/libs/smart-ngrx/src/types/child-type.type.ts
@@ -1,1 +1,0 @@
-export type ChildType = 'fixed' | 'virtual';

--- a/libs/smart-ngrx/src/types/smart-entity-definition.interface.ts
+++ b/libs/smart-ngrx/src/types/smart-entity-definition.interface.ts
@@ -1,6 +1,5 @@
 import { EntityAdapter } from '@ngrx/entity';
 
-import { ChildType } from './child-type.type';
 import { EffectServiceToken } from './effect-service.token';
 import { MarkAndDeleteInit } from './mark-and-delete-init.interface';
 import { SmartNgRXRowBase } from './smart-ngrx-row-base.interface';
@@ -38,17 +37,6 @@ export interface SmartEntityDefinition<Row extends SmartNgRXRowBase> {
    */
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- decorating with void because this should not use this.
   defaultRow(this: void, id: string): Row;
-
-  /**
-   * If a row has child fields, they should be defined here. The key is the
-   * name of the child field and the value is the type of child field.
-   *
-   * Types can be 'fixed' or 'virtual'. Fixed means that all the IDs for the
-   * child are returned with the row. Virtual means that only the number of
-   * items are returned and the IDs are fetched from the server when the row
-   * is accessed.
-   */
-  children?: Partial<Record<keyof Row, ChildType>>;
 
   /**
    * If this is true, the assumption is that this is the top level row that has


### PR DESCRIPTION
# Issue Number: #571

# Body

The code now checks to see if the array is an array. If it is, it uses the old way of dealing with child arrays. If not, it assumes it is a virtual array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified department structure by removing nested `children` properties from various department definitions, facilitating a flatter data model.
	- Enhanced clarity and performance in the handling of parent-child relationships in the application.

- **Bug Fixes**
	- Improved robustness of functions related to entity selection by modifying parameter inputs and removing unnecessary variables.

- **Tests**
	- Restructured the test cases for better maintainability following updates to the function parameters and logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->