### PR TITLE
refactor(smart-ngrx): don't call server when key starts with index-

### DIFF
--- a/apps/demo/src/app/shared/department-children/department-child-effects.service.spec.ts
+++ b/apps/demo/src/app/shared/department-children/department-child-effects.service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, of } from 'rxjs';
+
+import { DocsService } from '../docs/docs.service';
+import { FoldersService } from '../folders/folders.service';
+import { ListsService } from '../lists/lists.service';
+import { SprintFoldersService } from '../sprint-folders/sprint-folders.service';
+import { DepartmentChildEffectsService } from './department-child-effects.service';
+import { loadByIdsForType } from './load-by-ids-for-type.function';
+
+jest.mock('./load-by-ids-for-type.function');
+
+describe('DepartmentChildEffectsService', () => {
+  let service: DepartmentChildEffectsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DepartmentChildEffectsService,
+        { provide: DocsService, useValue: { loadByIds: jest.fn() } },
+        { provide: FoldersService, useValue: { loadByIds: jest.fn() } },
+        { provide: ListsService, useValue: { loadByIds: jest.fn() } },
+        { provide: SprintFoldersService, useValue: { loadByIds: jest.fn() } },
+      ],
+    });
+
+    service = TestBed.inject(DepartmentChildEffectsService);
+  });
+
+  it('should load documents, folders, lists, and sprint folders by ids', async () => {
+    const ids = ['docs:1', 'folders:2', 'lists:3', 'sprint-folders:4'];
+    const docResult = [{ id: 'docs:1', name: 'Doc1' }];
+    const folderResult = [{ id: 'folders:2', name: 'Folder2' }];
+    const listResult = [{ id: 'lists:3', name: 'List3' }];
+    const sprintFolderResult = [
+      { id: 'sprint-folders:4', name: 'SprintFolder4' },
+    ];
+
+    (loadByIdsForType as jest.Mock).mockImplementation((_, __, type) => {
+      switch (type) {
+        case 'docs':
+          return of(docResult);
+        case 'folders':
+          return of(folderResult);
+        case 'lists':
+          return of(listResult);
+        case 'sprint-folders':
+          return of(sprintFolderResult);
+        default:
+          return of([]);
+      }
+    });
+
+    const result = await firstValueFrom(service.loadByIds(ids));
+    expect(result).toEqual([
+      ...docResult,
+      ...folderResult,
+      ...listResult,
+      ...sprintFolderResult,
+    ]);
+  });
+
+  it('should return empty arrays when no ids are provided', async () => {
+    const ids: string[] = [];
+
+    const result = await firstValueFrom(service.loadByIds(ids));
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty arrays when no matching ids are provided', async () => {
+    const ids = ['unknown:1'];
+
+    const result = await firstValueFrom(service.loadByIds(ids));
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
+++ b/apps/demo/src/app/shared/department-children/department-child-effects.service.ts
@@ -33,15 +33,27 @@ export class DepartmentChildEffectsService extends EffectService<DepartmentChild
     const listIds = filterIds(ids, this.listPrefix);
     const sprintFolderIds = filterIds(ids, this.sprintFolderPrefix);
 
-    const docStream = loadByIdsForType(this.doc, docIds, this.docs, 'did');
+    const docStream =
+      docIds.length > 0
+        ? loadByIdsForType(this.doc, docIds, this.docs, 'did')
+        : of([]);
 
-    const folderStream = loadByIdsForType(this.folder, folderIds, this.folders);
-    const listStream = loadByIdsForType(this.list, listIds, this.lists);
-    const sprintFolderStream = loadByIdsForType(
-      this.sprintFolder,
-      sprintFolderIds,
-      this.sprintFolders,
-    );
+    const folderStream =
+      folderIds.length > 0
+        ? loadByIdsForType(this.folder, folderIds, this.folders)
+        : of([]);
+    const listStream =
+      listIds.length > 0
+        ? loadByIdsForType(this.list, listIds, this.lists)
+        : of([]);
+    const sprintFolderStream =
+      sprintFolderIds.length > 0
+        ? loadByIdsForType(
+            this.sprintFolder,
+            sprintFolderIds,
+            this.sprintFolders,
+          )
+        : of([]);
 
     return forkJoin({
       docs: docStream,

--- a/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
+++ b/libs/smart-ngrx/src/effects/effects-factory/load-by-ids-effect.function.ts
@@ -1,6 +1,6 @@
 import { inject, InjectionToken, NgZone } from '@angular/core';
 import { Actions, ofType } from '@ngrx/effects';
-import { map, mergeMap } from 'rxjs';
+import { filter, map, mergeMap, Observable } from 'rxjs';
 
 import { ActionGroup } from '../../actions/action-group.interface';
 import { actionServiceRegistry } from '../../registrations/action.service.registry';
@@ -34,7 +34,9 @@ export function loadByIdsEffect<T extends SmartNgRXRowBase>(
     return actions$.pipe(
       ofType(actions.loadByIds),
       bufferIdsAction(zone),
-      mergeMap((ids) => {
+      map((ids) => ids.filter((c) => !c.startsWith('index-'))),
+      filter((ids) => ids.length > 0),
+      mergeMap((ids): Observable<T[]> => {
         return actionService.loadByIds(ids);
       }),
       map((rows) => {


### PR DESCRIPTION
# Issue Number: #573 

# Body

Refactors the code so that it doesn't call the server when the ID starts with `index-`
Also updates the department-child-effects.service.ts so that it doesn't call the sub-services if the array is empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `DepartmentChildEffectsService` to check for empty ID arrays before loading data, improving performance and robustness.
  - Introduced filtering logic in the `loadByIdsEffect` function to process only valid IDs, ensuring efficient data handling.

- **Bug Fixes**
  - Improved error handling by preventing unnecessary calls when ID arrays are empty.

- **Tests**
  - Added a comprehensive test suite for the `DepartmentChildEffectsService`, validating functionality and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->