### PR TITLE
Fix delete with virtual array not working

### DIFF
--- a/apps/demo/src/app/shared/components/tree/tree-component.service.ts
+++ b/apps/demo/src/app/shared/components/tree/tree-component.service.ts
@@ -111,6 +111,10 @@ export class TreeComponentService {
     // but it actually exist by definition,
     // we can safely assert that it exist.
     node.node.delete!();
+    // Update the virtual array without refreshing the screen
+    if (this.virtualArrayFlagService.virtualArrayFlag) {
+      this.applyRange();
+    }
   }
 
   cancelEdit(node: TreeNode): void {

--- a/libs/smart-ngrx/src/actions/action.service.ts
+++ b/libs/smart-ngrx/src/actions/action.service.ts
@@ -252,6 +252,14 @@ export class ActionService {
         parentInfo,
       }),
     );
+
+    // Update the virtual array without refreshing the screen
+    this.entities.pipe(take(1)).subscribe((entities) => {
+      const entity = entities[id];
+      if (entity && entity.virtualChildren) {
+        entity.virtualChildren.removeFromStore!(entity, entity);
+      }
+    });
   }
 
   /**

--- a/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
+++ b/libs/smart-ngrx/src/row-proxy/row-proxy.class.ts
@@ -90,5 +90,12 @@ export class RowProxy<T extends SmartNgRXRowBase = SmartNgRXRowBase>
   delete(): void {
     const id = this.service.entityAdapter.selectId(this.row) as string;
     this.service.delete(id);
+    // Update the virtual array without refreshing the screen
+    this.service.entities.pipe(take(1)).subscribe((entities) => {
+      const entity = entities[id];
+      if (entity && entity.virtualChildren) {
+        entity.virtualChildren.removeFromStore!(this.row, entity);
+      }
+    });
   }
 }

--- a/libs/smart-ngrx/src/socket/delete-entity.function.ts
+++ b/libs/smart-ngrx/src/socket/delete-entity.function.ts
@@ -2,6 +2,7 @@ import { ParentInfo } from '../actions/parent-info.interface';
 import { removeIdFromParents } from '../actions/remove-id-from-parents.function';
 import { forNext } from '../common/for-next.function';
 import { childDefinitionRegistry } from '../registrations/child-definition.registry';
+import { actionServiceRegistry } from '../registrations/action.service.registry';
 
 /**
  * Delete the feature/entity/ids from the store
@@ -20,6 +21,17 @@ export function deleteEntity(feature: string, entity: string, ids: string[]) {
     forNext(ids, (id) => {
       // This doesn't make a database call, it just updates the store.
       removeIdFromParents(childDefinition, id, parentInfo);
+    });
+  });
+
+  // Update the virtual array without refreshing the screen
+  const actionService = actionServiceRegistry(feature, entity);
+  actionService.entities.pipe(take(1)).subscribe((entities) => {
+    forNext(ids, (id) => {
+      const entity = entities[id];
+      if (entity && entity.virtualChildren) {
+        entity.virtualChildren.removeFromStore!(entity, entity);
+      }
     });
   });
 }


### PR DESCRIPTION
Fixes #645

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DaveMBush/SmartNgRX/issues/645?shareId=383363dd-4ec9-41a5-a7bd-c8cae4f1279f).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced delete functionality to update the virtual array without requiring a screen refresh when nodes or entities are deleted.
  
- **Bug Fixes**
	- Improved handling of virtual children during deletion processes, ensuring data integrity and representation.

- **Refactor**
	- Streamlined logic in delete methods across multiple services for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->