### PR TITLE
feat: flesh out signals demo

### DIFF
--- a/apps/demo-ngrx-signals/src/app/app.routes.ts
+++ b/apps/demo-ngrx-signals/src/app/app.routes.ts
@@ -2,11 +2,22 @@ import { Type } from '@angular/core';
 import { Routes } from '@angular/router';
 import { provideSmartFeatureSignalEntities } from '@smarttools/smart-signals';
 
+import { noDirtySignalsDepartmentsDefinition } from './routes/tree-no-dirty/store/department/no-dirty-signals-departments-definition';
+import { noDirtySignalsDepartmentChildrenDefinition } from './routes/tree-no-dirty/store/department-children/no-dirty-signals-department-children-definition';
+import { noDirtySignalsLocationsDefinition } from './routes/tree-no-dirty/store/locations/no-dirty-signals-locations-definition';
+import { noDirtySignalsTopDefinition } from './routes/tree-no-dirty/store/top/no-dirty-signals-top-definition.const';
+import { noRefreshSignalsDepartmentsDefinition } from './routes/tree-no-refresh/store/department/no-refresh-signals-departments-definition';
+import { noRefreshSignalsDepartmentChildrenDefinition } from './routes/tree-no-refresh/store/department-children/standard-signals-department-children-definition';
+import { noRefreshSignalsLocationsDefinition } from './routes/tree-no-refresh/store/locations/no-refresh-signals-locations-definition';
+import { noRefreshSignalsTopDefinition } from './routes/tree-no-refresh/store/top/no-refresh-signals-top-definition.const';
+import { noRemoveSignalsDepartmentsDefinition } from './routes/tree-no-remove/store/department/no-remove-signals-departments-definition';
+import { noRemoveSignalsDepartmentChildrenDefinition } from './routes/tree-no-remove/store/department-children/no-remove-signals-department-children-definition';
+import { noRemoveSignalsLocationsDefinition } from './routes/tree-no-remove/store/locations/no-remove-signals-locations-definition';
+import { noRemoveSignalsTopDefinition } from './routes/tree-no-remove/store/top/no-remove-signals-top-definition.const';
 import { standardSignalsDepartmentsDefinition } from './routes/tree-standard/store/department/standard-signals-departments-definition';
 import { standardSignalsDepartmentChildrenDefinition } from './routes/tree-standard/store/department-children/standard-signals-department-children-definition';
 import { standardSignalsLocationsDefinition } from './routes/tree-standard/store/locations/standard-signals-locations-definition';
 import { standardSignalsTopDefinition } from './routes/tree-standard/store/top/standard-signals-top-definition.const';
-
 // This ensure we have one key per SharedState property
 
 export const appRoutes: Routes = [
@@ -34,6 +45,54 @@ export const appRoutes: Routes = [
         standardSignalsLocationsDefinition,
         standardSignalsDepartmentsDefinition,
         standardSignalsDepartmentChildrenDefinition,
+      ]),
+    ],
+  },
+  {
+    path: 'treeNoRefresh',
+    loadComponent: async function treeNoRefreshRoute(): Promise<Type<unknown>> {
+      return (await import('./routes/tree-no-refresh/tree.component'))
+        .TreeComponent;
+    },
+    providers: [
+      //currentLocationSignalStore,
+      provideSmartFeatureSignalEntities('tree-no-refresh', [
+        noRefreshSignalsTopDefinition,
+        noRefreshSignalsLocationsDefinition,
+        noRefreshSignalsDepartmentsDefinition,
+        noRefreshSignalsDepartmentChildrenDefinition,
+      ]),
+    ],
+  },
+  {
+    path: 'treeNoRemove',
+    loadComponent: async function treeNoRemoveRoute(): Promise<Type<unknown>> {
+      return (await import('./routes/tree-no-remove/tree.component'))
+        .TreeComponent;
+    },
+    providers: [
+      //currentLocationSignalStore,
+      provideSmartFeatureSignalEntities('tree-no-remove', [
+        noRemoveSignalsTopDefinition,
+        noRemoveSignalsLocationsDefinition,
+        noRemoveSignalsDepartmentsDefinition,
+        noRemoveSignalsDepartmentChildrenDefinition,
+      ]),
+    ],
+  },
+  {
+    path: 'treeNoDirty',
+    loadComponent: async function treeNoDirtyRoute(): Promise<Type<unknown>> {
+      return (await import('./routes/tree-no-dirty/tree.component'))
+        .TreeComponent;
+    },
+    providers: [
+      //currentLocationSignalStore,
+      provideSmartFeatureSignalEntities('tree-no-dirty', [
+        noDirtySignalsTopDefinition,
+        noDirtySignalsLocationsDefinition,
+        noDirtySignalsDepartmentsDefinition,
+        noDirtySignalsDepartmentChildrenDefinition,
       ]),
     ],
   },

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/feature.const.ts
@@ -1,0 +1,1 @@
+export const featureName = 'tree-standard';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/feature.const.ts
@@ -1,1 +1,1 @@
-export const featureName = 'tree-no-refresh';
+export const featureName = 'tree-no-dirty';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/feature.const.ts
@@ -1,1 +1,1 @@
-export const featureName = 'tree-standard';
+export const featureName = 'tree-no-refresh';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/current-location/current-location.signal-store.spec.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/current-location/current-location.signal-store.spec.ts
@@ -1,0 +1,139 @@
+import { TestBed } from '@angular/core/testing';
+
+// Create a simplified Location interface for testing
+interface Location {
+  id: string;
+  name: string;
+  departments: unknown[];
+}
+
+// Mock data - create before the mock
+const mockLocations: Location[] = [];
+
+// Create mock signal function that we'll use across tests
+const mockSignalFn = jest.fn().mockReturnValue(mockLocations);
+
+// Create a mock for selectLocations that we can spy on
+const mockSelectLocations = jest.fn().mockReturnValue(mockSignalFn);
+
+// Mock the module before importing
+jest.mock('../locations/selectors/select-locations.selector', () => ({
+  selectLocations: mockSelectLocations,
+}));
+
+// Now import the module under test
+import { currentLocationSignalStore } from './current-location.signal-store';
+
+describe('currentLocationSignalStore', () => {
+  let store: InstanceType<typeof currentLocationSignalStore>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [currentLocationSignalStore],
+    });
+
+    // Reset test data
+    mockLocations.length = 0;
+
+    // Clear all mock calls and implementations
+    jest.clearAllMocks();
+    mockSignalFn.mockClear();
+    mockSelectLocations.mockClear();
+
+    // Ensure the mock function returns our signal function
+    mockSelectLocations.mockReturnValue(mockSignalFn);
+
+    // Get a fresh instance of the store
+    store = TestBed.inject(currentLocationSignalStore);
+  });
+
+  describe('setCurrentLocationId', () => {
+    it('should update the currentLocationId state', () => {
+      // Initial value should be empty
+      expect(store.currentLocationId()).toBe('');
+
+      // Set a new location ID
+      store.setCurrentLocationId('location1');
+
+      // State should be updated
+      expect(store.currentLocationId()).toBe('location1');
+    });
+  });
+
+  describe('selectCurrentLocationId', () => {
+    it('should return the currentLocationId when it has a value', () => {
+      // Set up test data
+      mockLocations.push(
+        { id: 'location2', name: 'Location 2', departments: [] },
+        { id: 'location3', name: 'Location 3', departments: [] },
+      );
+
+      // Set a location ID
+      store.setCurrentLocationId('location1');
+
+      // Should prioritize the current location ID
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('location1');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return the first location ID when currentLocationId is empty and locations exist', () => {
+      // Set up test data with valid objects
+      mockLocations.push(
+        { id: 'location1', name: 'Location 1', departments: [] },
+        { id: 'location2', name: 'Location 2', departments: [] },
+      );
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('location1');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return empty string when currentLocationId is empty and locations are empty', () => {
+      // Empty locations array (default state)
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return empty string when currentLocationId is empty and locations are not objects', () => {
+      // Set up non-object locations
+      const nonObjects = ['not an object', 'also not an object'];
+      // Replace mockLocations.push with direct assignment
+      mockSignalFn.mockReturnValue(nonObjects);
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/current-location/current-location.signal-store.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/current-location/current-location.signal-store.ts
@@ -1,0 +1,47 @@
+import { computed } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+
+import { selectLocations } from '../locations/selectors/select-locations.selector';
+import { TreeStandardState2 } from '../tree-standard-state2.interface';
+
+export const currentLocationSignalStore = signalStore(
+  { providedIn: 'root' },
+  withState({
+    currentLocationId: '',
+  } as TreeStandardState2),
+  withMethods(function withMethodsFunction(store) {
+    return {
+      setCurrentLocationId: function setCurrentLocationId(
+        currentLocationId: string,
+      ): void {
+        patchState(store, function setCurrentLocationIdPatch(state) {
+          return { ...state, currentLocationId };
+        });
+      },
+    };
+  }),
+  withComputed(function computedFunction({ currentLocationId }) {
+    const locationsSignal = selectLocations();
+
+    return {
+      selectCurrentLocationId: computed(
+        function selectCurrentLocationIdComputedFunction(): string {
+          const locations = locationsSignal();
+          if (currentLocationId().length > 0) {
+            return currentLocationId();
+          }
+          if (locations.length > 0 && typeof locations[0] === 'object') {
+            return locations[0].id;
+          }
+          return '';
+        },
+      ),
+    };
+  }),
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/current-location/select-current-location.signal.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/current-location/select-current-location.signal.ts
@@ -1,0 +1,47 @@
+import { computed, Signal } from '@angular/core';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { selectLocationsDepartments } from '../locations/selectors/select-locations-departments.selectors';
+import { currentLocationSignalStore } from './current-location.signal-store';
+
+// Define the store instance type to properly type the parameter
+type CurrentLocationStore = InstanceType<typeof currentLocationSignalStore>;
+
+export function selectCurrentLocationSignal(
+  store: CurrentLocationStore,
+): Signal<{
+  id: string;
+  name: string;
+  departments: Department[] | string[];
+}> {
+  return computed(function selectCurrentLocation() {
+    const currentLocationId = store.selectCurrentLocationId();
+
+    // First get the location with departments
+    const locationDepartmentsSignal = selectLocationsDepartments;
+    const locationState = locationDepartmentsSignal();
+
+    const location = locationState.entities[currentLocationId];
+
+    /* the if is difficult to test because it requires
+       facadeRegistry.register() to be called first which
+       is difficult to arrange in a test.
+    */
+    /* istanbul ignore if */
+    if (location) {
+      // The departments array should automatically handle its child signals
+      const departments = location.departments;
+
+      return {
+        ...location,
+        departments,
+      };
+    }
+
+    return {
+      id: '',
+      name: '',
+      departments: [],
+    };
+  });
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department-children/department-child.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department-children/department-child.selector.ts
@@ -1,0 +1,9 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
+import { featureName } from '../../feature.const';
+
+export const selectDepartmentChildren = createSmartSignal<DepartmentChild>(
+  featureName,
+  'departmentChildren',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department-children/no-dirty-signals-department-children-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department-children/no-dirty-signals-department-children-definition.ts
@@ -1,0 +1,26 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
+import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';
+
+export const noDirtySignalsDepartmentChildrenDefinition: SmartEntityDefinition<DepartmentChild> =
+  {
+    entityName: 'departmentChildren',
+    effectServiceToken: departmentChildEffectsServiceToken,
+    markAndDelete: {
+      markDirtyTime: -1,
+    },
+
+    isSignal: true,
+    defaultRow: function noDirtyDepartmentChildrenDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        children: {
+          indexes: [],
+          startIndex: 0,
+          length: 0,
+        },
+      };
+    },
+  };

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department/no-dirty-signals-departments-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department/no-dirty-signals-departments-definition.ts
@@ -1,0 +1,26 @@
+/* jscpd:ignore-start -- intentionally duplicated */
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';
+
+export const noDirtySignalsDepartmentsDefinition: SmartEntityDefinition<Department> =
+  {
+    entityName: 'departments',
+    effectServiceToken: departmentEffectsServiceToken,
+    markAndDelete: {
+      markDirtyTime: -1,
+    },
+    isSignal: true,
+    defaultRow: function noDirtyDepartmentsDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        children: {
+          indexes: [],
+          length: 0,
+        },
+      };
+    },
+  };
+/* jscpd:ignore-end */

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department/select-departments-children.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department/select-departments-children.selector.ts
@@ -1,0 +1,19 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../feature.const';
+import { selectDepartmentChildren } from '../department-children/department-child.selector';
+import { selectDepartments } from './select-departments.selector';
+
+export const selectDepartmentsChildren = createSmartSignal(selectDepartments, [
+  {
+    childFeature: featureName,
+    childEntity: 'departmentChildren',
+    parentFeature: featureName,
+    parentEntity: 'departments',
+    parentField: 'children',
+    childSelector: selectDepartmentChildren,
+  },
+]);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department/select-departments.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/department/select-departments.selector.ts
@@ -1,0 +1,9 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { featureName } from '../../feature.const';
+
+export const selectDepartments = createSmartSignal<Department>(
+  featureName,
+  'departments',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/no-dirty-signals-locations-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/no-dirty-signals-locations-definition.ts
@@ -1,0 +1,21 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Location } from '../../../../shared/locations/location.interface';
+import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';
+
+export const noDirtySignalsLocationsDefinition: SmartEntityDefinition<Location> =
+  {
+    entityName: 'locations',
+    effectServiceToken: locationEffectsServiceToken,
+    markAndDelete: {
+      markDirtyTime: -1,
+    },
+    isSignal: true,
+    defaultRow: function noDirtyLocationsDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        departments: [],
+      };
+    },
+  };

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-location-entities.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-location-entities.selectors.ts
@@ -1,0 +1,8 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { featureName } from '../../../feature.const';
+export const selectLocationEntities = createSmartSignal<Location>(
+  featureName,
+  'locations',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-locations-departments.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-locations-departments.selectors.ts
@@ -1,0 +1,22 @@
+// jscpd:ignore-start
+// intentionally duplicated because it is for different state for demo purposes
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../../feature.const';
+import { selectDepartmentsChildren } from '../../department/select-departments-children.selector';
+import { selectLocationEntities } from './select-location-entities.selectors';
+
+export const selectLocationsDepartments = createSmartSignal(
+  selectLocationEntities,
+  [
+    {
+      childFeature: featureName,
+      childEntity: 'departments',
+      parentField: 'departments',
+      parentFeature: featureName,
+      parentEntity: 'locations',
+      childSelector: selectDepartmentsChildren,
+    },
+  ],
+);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-locations.selector.spec.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-locations.selector.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { selectLocations } from './select-locations.selector';
+
+// Mock the entire module and its functions
+jest.mock('../../top/select-top-locations.selectors', () => {
+  return {
+    selectTopLocations: jest.fn(),
+  };
+});
+
+// Import after mocking
+import { selectTopLocations } from '../../top/select-top-locations.selectors';
+
+// Constants for reused values
+const location1Id = 'loc1';
+const location1Name = 'Location 1';
+const location2Id = 'loc2';
+const location2Name = 'Location 2';
+
+// Create location objects that match the expected type
+const mockLocationObjects: Location[] = [
+  { id: location1Id, name: location1Name, departments: [] },
+  { id: location2Id, name: location2Name, departments: [] },
+];
+
+// Mock implementation helper that ensures the computed function is called
+function setupMockSelector(returnValue: unknown): void {
+  (selectTopLocations as unknown as jest.Mock).mockReturnValue(returnValue);
+}
+
+describe('selectLocations', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    jest.clearAllMocks();
+  });
+
+  it('should return location objects when conditions are met', () => {
+    // Set up mock for success case
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: mockLocationObjects,
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual(mockLocationObjects);
+  });
+
+  it('should handle multiple IDs', () => {
+    // Set up mock for multiple IDs
+    setupMockSelector({
+      ids: ['top1', 'top2'],
+      entities: {
+        top1: { id: 'top1', locations: mockLocationObjects },
+        top2: { id: 'top2', locations: mockLocationObjects },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle missing entity', () => {
+    // Set up mock for missing entity
+    setupMockSelector({
+      ids: ['nonExistentId'],
+      entities: {},
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty locations', () => {
+    // Set up mock for empty locations
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: [],
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle non-object locations', () => {
+    // Set up mock for string locations
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: ['not an object', 'not an object'],
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-locations.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/locations/selectors/select-locations.selector.ts
@@ -1,0 +1,27 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { computed, Signal } from '@angular/core';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { selectTopLocations } from '../../top/select-top-locations.selectors';
+
+export function selectLocations(): Signal<Location[]> {
+  return computed(function selectLocationsFunction() {
+    const tops = selectTopLocations();
+    // Instead of directly accessing .locations, we should get the full entity
+    // which will trigger the smart signal chain
+    if (tops.ids.length === 1) {
+      const topEntity = tops.entities[tops.ids[0]];
+      if (
+        topEntity &&
+        topEntity.locations.length > 0 &&
+        typeof topEntity.locations[0] === 'object'
+      ) {
+        // This will now use the smart signal chain through selectLocationsDepartments
+        return topEntity.locations as Location[];
+      }
+    }
+    return [] as Location[];
+  });
+}
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/selectors/select-tree-standard-signals-state.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/selectors/select-tree-standard-signals-state.selectors.ts
@@ -1,0 +1,7 @@
+import { createFeatureSelector } from '@ngrx/store';
+
+import { featureName } from '../../feature.const';
+import { TreeStandardState } from '../tree-standard-state.interface';
+
+export const selectTreeStandardSignalsState =
+  createFeatureSelector<TreeStandardState>(featureName);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/top/no-dirty-signals-top-definition.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/top/no-dirty-signals-top-definition.const.ts
@@ -1,0 +1,20 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Top } from '../../../../shared/top/top.interface';
+import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';
+
+export const noDirtySignalsTopDefinition: SmartEntityDefinition<Top> = {
+  entityName: 'top',
+  effectServiceToken: topEffectsServiceToken,
+  markAndDelete: {
+    markDirtyTime: -1,
+  },
+  isInitialRow: true,
+  isSignal: true,
+  defaultRow: function noDirtyTopDefaultRowFunction(id) {
+    return {
+      id,
+      locations: [],
+    };
+  },
+};

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/top/select-top-entities.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/top/select-top-entities.selectors.ts
@@ -1,0 +1,5 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Top } from '../../../../shared/top/top.interface';
+import { featureName } from '../../feature.const';
+export const selectTopEntities = createSmartSignal<Top>(featureName, 'top');

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/top/select-top-locations.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/top/select-top-locations.selectors.ts
@@ -1,0 +1,19 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../feature.const';
+import { selectLocationsDepartments } from '../locations/selectors/select-locations-departments.selectors';
+import { selectTopEntities } from './select-top-entities.selectors';
+
+export const selectTopLocations = createSmartSignal(selectTopEntities, [
+  {
+    childFeature: featureName,
+    childEntity: 'locations',
+    parentField: 'locations',
+    parentFeature: featureName,
+    parentEntity: 'top',
+    childSelector: selectLocationsDepartments,
+  },
+]);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/tree-standard-state.interface.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/tree-standard-state.interface.ts
@@ -1,0 +1,11 @@
+import { DepartmentChildEntity } from '../../../shared/entities/department-child-entity.type';
+import { DepartmentEntity } from '../../../shared/entities/department-entity.type';
+import { LocationEntity } from '../../../shared/entities/location-entity.type';
+import { TopEntity } from '../../../shared/entities/top-entity.type';
+
+export interface TreeStandardState {
+  top: TopEntity;
+  locations: LocationEntity;
+  departments: DepartmentEntity;
+  departmentChildren: DepartmentChildEntity;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/tree-standard-state2.interface.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/store/tree-standard-state2.interface.ts
@@ -1,0 +1,3 @@
+export interface TreeStandardState2 {
+  currentLocationId: string;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/tree.component.css
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/tree.component.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  height: 100%;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/tree.component.html
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/tree.component.html
@@ -1,0 +1,6 @@
+<dmb-tree
+  [locations$]="locations$()"
+  [locationId$]="locationId$()"
+  [location$]="location$()"
+  (locationChanged)="locationChanged($event)"
+></dmb-tree>

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/tree.component.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-dirty/tree.component.ts
@@ -1,0 +1,32 @@
+// jscpd:ignore-start
+// component is intentionally duplicated.
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { TreeComponent as SharedTreeComponent } from '../../shared/components/tree/tree.component';
+import { currentLocationSignalStore } from './store/current-location/current-location.signal-store';
+import { selectCurrentLocationSignal } from './store/current-location/select-current-location.signal';
+import { selectLocations } from './store/locations/selectors/select-locations.selector';
+@Component({
+  selector: 'dmb-demo-tree',
+  standalone: true,
+  imports: [CommonModule, SharedTreeComponent],
+  templateUrl: './tree.component.html',
+  styleUrls: ['./tree.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [currentLocationSignalStore],
+})
+export class TreeComponent {
+  currentLocationSignalStore = inject(currentLocationSignalStore);
+  locationId$ = this.currentLocationSignalStore.selectCurrentLocationId;
+  locations$ = selectLocations();
+
+  // Create the computed signal directly in the component
+
+  location$ = selectCurrentLocationSignal(this.currentLocationSignalStore);
+
+  locationChanged(event: string): void {
+    this.currentLocationSignalStore.setCurrentLocationId(event);
+  }
+}
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/feature.const.ts
@@ -1,0 +1,1 @@
+export const featureName = 'tree-standard';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/feature.const.ts
@@ -1,1 +1,1 @@
-export const featureName = 'tree-standard';
+export const featureName = 'tree-no-refresh';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/current-location/current-location.signal-store.spec.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/current-location/current-location.signal-store.spec.ts
@@ -1,0 +1,139 @@
+import { TestBed } from '@angular/core/testing';
+
+// Create a simplified Location interface for testing
+interface Location {
+  id: string;
+  name: string;
+  departments: unknown[];
+}
+
+// Mock data - create before the mock
+const mockLocations: Location[] = [];
+
+// Create mock signal function that we'll use across tests
+const mockSignalFn = jest.fn().mockReturnValue(mockLocations);
+
+// Create a mock for selectLocations that we can spy on
+const mockSelectLocations = jest.fn().mockReturnValue(mockSignalFn);
+
+// Mock the module before importing
+jest.mock('../locations/selectors/select-locations.selector', () => ({
+  selectLocations: mockSelectLocations,
+}));
+
+// Now import the module under test
+import { currentLocationSignalStore } from './current-location.signal-store';
+
+describe('currentLocationSignalStore', () => {
+  let store: InstanceType<typeof currentLocationSignalStore>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [currentLocationSignalStore],
+    });
+
+    // Reset test data
+    mockLocations.length = 0;
+
+    // Clear all mock calls and implementations
+    jest.clearAllMocks();
+    mockSignalFn.mockClear();
+    mockSelectLocations.mockClear();
+
+    // Ensure the mock function returns our signal function
+    mockSelectLocations.mockReturnValue(mockSignalFn);
+
+    // Get a fresh instance of the store
+    store = TestBed.inject(currentLocationSignalStore);
+  });
+
+  describe('setCurrentLocationId', () => {
+    it('should update the currentLocationId state', () => {
+      // Initial value should be empty
+      expect(store.currentLocationId()).toBe('');
+
+      // Set a new location ID
+      store.setCurrentLocationId('location1');
+
+      // State should be updated
+      expect(store.currentLocationId()).toBe('location1');
+    });
+  });
+
+  describe('selectCurrentLocationId', () => {
+    it('should return the currentLocationId when it has a value', () => {
+      // Set up test data
+      mockLocations.push(
+        { id: 'location2', name: 'Location 2', departments: [] },
+        { id: 'location3', name: 'Location 3', departments: [] },
+      );
+
+      // Set a location ID
+      store.setCurrentLocationId('location1');
+
+      // Should prioritize the current location ID
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('location1');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return the first location ID when currentLocationId is empty and locations exist', () => {
+      // Set up test data with valid objects
+      mockLocations.push(
+        { id: 'location1', name: 'Location 1', departments: [] },
+        { id: 'location2', name: 'Location 2', departments: [] },
+      );
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('location1');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return empty string when currentLocationId is empty and locations are empty', () => {
+      // Empty locations array (default state)
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return empty string when currentLocationId is empty and locations are not objects', () => {
+      // Set up non-object locations
+      const nonObjects = ['not an object', 'also not an object'];
+      // Replace mockLocations.push with direct assignment
+      mockSignalFn.mockReturnValue(nonObjects);
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/current-location/current-location.signal-store.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/current-location/current-location.signal-store.ts
@@ -1,0 +1,47 @@
+import { computed } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+
+import { selectLocations } from '../locations/selectors/select-locations.selector';
+import { TreeStandardState2 } from '../tree-standard-state2.interface';
+
+export const currentLocationSignalStore = signalStore(
+  { providedIn: 'root' },
+  withState({
+    currentLocationId: '',
+  } as TreeStandardState2),
+  withMethods(function withMethodsFunction(store) {
+    return {
+      setCurrentLocationId: function setCurrentLocationId(
+        currentLocationId: string,
+      ): void {
+        patchState(store, function setCurrentLocationIdPatch(state) {
+          return { ...state, currentLocationId };
+        });
+      },
+    };
+  }),
+  withComputed(function computedFunction({ currentLocationId }) {
+    const locationsSignal = selectLocations();
+
+    return {
+      selectCurrentLocationId: computed(
+        function selectCurrentLocationIdComputedFunction(): string {
+          const locations = locationsSignal();
+          if (currentLocationId().length > 0) {
+            return currentLocationId();
+          }
+          if (locations.length > 0 && typeof locations[0] === 'object') {
+            return locations[0].id;
+          }
+          return '';
+        },
+      ),
+    };
+  }),
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/current-location/select-current-location.signal.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/current-location/select-current-location.signal.ts
@@ -1,0 +1,47 @@
+import { computed, Signal } from '@angular/core';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { selectLocationsDepartments } from '../locations/selectors/select-locations-departments.selectors';
+import { currentLocationSignalStore } from './current-location.signal-store';
+
+// Define the store instance type to properly type the parameter
+type CurrentLocationStore = InstanceType<typeof currentLocationSignalStore>;
+
+export function selectCurrentLocationSignal(
+  store: CurrentLocationStore,
+): Signal<{
+  id: string;
+  name: string;
+  departments: Department[] | string[];
+}> {
+  return computed(function selectCurrentLocation() {
+    const currentLocationId = store.selectCurrentLocationId();
+
+    // First get the location with departments
+    const locationDepartmentsSignal = selectLocationsDepartments;
+    const locationState = locationDepartmentsSignal();
+
+    const location = locationState.entities[currentLocationId];
+
+    /* the if is difficult to test because it requires
+       facadeRegistry.register() to be called first which
+       is difficult to arrange in a test.
+    */
+    /* istanbul ignore if */
+    if (location) {
+      // The departments array should automatically handle its child signals
+      const departments = location.departments;
+
+      return {
+        ...location,
+        departments,
+      };
+    }
+
+    return {
+      id: '',
+      name: '',
+      departments: [],
+    };
+  });
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department-children/department-child.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department-children/department-child.selector.ts
@@ -1,0 +1,9 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
+import { featureName } from '../../feature.const';
+
+export const selectDepartmentChildren = createSmartSignal<DepartmentChild>(
+  featureName,
+  'departmentChildren',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department-children/standard-signals-department-children-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department-children/standard-signals-department-children-definition.ts
@@ -1,0 +1,23 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
+import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';
+import { markAndDelete } from '../mark-and-delete-init';
+export const noRefreshSignalsDepartmentChildrenDefinition: SmartEntityDefinition<DepartmentChild> =
+  {
+    entityName: 'departmentChildren',
+    effectServiceToken: departmentChildEffectsServiceToken,
+    markAndDelete,
+    isSignal: true,
+    defaultRow: function noRefreshDepartmentChildrenDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        children: {
+          indexes: [],
+          startIndex: 0,
+          length: 0,
+        },
+      };
+    },
+  };

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department/no-refresh-signals-departments-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department/no-refresh-signals-departments-definition.ts
@@ -1,0 +1,25 @@
+/* jscpd:ignore-start -- intentionally duplicated */
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';
+import { markAndDelete } from '../mark-and-delete-init';
+
+export const noRefreshSignalsDepartmentsDefinition: SmartEntityDefinition<Department> =
+  {
+    entityName: 'departments',
+    effectServiceToken: departmentEffectsServiceToken,
+    markAndDelete,
+    isSignal: true,
+    defaultRow: function noRefreshDepartmentsDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        children: {
+          indexes: [],
+          length: 0,
+        },
+      };
+    },
+  };
+/* jscpd:ignore-end */

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department/select-departments-children.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department/select-departments-children.selector.ts
@@ -1,0 +1,19 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../feature.const';
+import { selectDepartmentChildren } from '../department-children/department-child.selector';
+import { selectDepartments } from './select-departments.selector';
+
+export const selectDepartmentsChildren = createSmartSignal(selectDepartments, [
+  {
+    childFeature: featureName,
+    childEntity: 'departmentChildren',
+    parentFeature: featureName,
+    parentEntity: 'departments',
+    parentField: 'children',
+    childSelector: selectDepartmentChildren,
+  },
+]);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department/select-departments.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/department/select-departments.selector.ts
@@ -1,0 +1,9 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { featureName } from '../../feature.const';
+
+export const selectDepartments = createSmartSignal<Department>(
+  featureName,
+  'departments',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/no-refresh-signals-locations-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/no-refresh-signals-locations-definition.ts
@@ -1,0 +1,19 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Location } from '../../../../shared/locations/location.interface';
+import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';
+import { markAndDelete } from '../mark-and-delete-init';
+export const noRefreshSignalsLocationsDefinition: SmartEntityDefinition<Location> =
+  {
+    entityName: 'locations',
+    effectServiceToken: locationEffectsServiceToken,
+    markAndDelete,
+    isSignal: true,
+    defaultRow: function noRefreshLocationsDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        departments: [],
+      };
+    },
+  };

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-location-entities.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-location-entities.selectors.ts
@@ -1,0 +1,8 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { featureName } from '../../../feature.const';
+export const selectLocationEntities = createSmartSignal<Location>(
+  featureName,
+  'locations',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-locations-departments.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-locations-departments.selectors.ts
@@ -1,0 +1,22 @@
+// jscpd:ignore-start
+// intentionally duplicated because it is for different state for demo purposes
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../../feature.const';
+import { selectDepartmentsChildren } from '../../department/select-departments-children.selector';
+import { selectLocationEntities } from './select-location-entities.selectors';
+
+export const selectLocationsDepartments = createSmartSignal(
+  selectLocationEntities,
+  [
+    {
+      childFeature: featureName,
+      childEntity: 'departments',
+      parentField: 'departments',
+      parentFeature: featureName,
+      parentEntity: 'locations',
+      childSelector: selectDepartmentsChildren,
+    },
+  ],
+);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-locations.selector.spec.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-locations.selector.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { selectLocations } from './select-locations.selector';
+
+// Mock the entire module and its functions
+jest.mock('../../top/select-top-locations.selectors', () => {
+  return {
+    selectTopLocations: jest.fn(),
+  };
+});
+
+// Import after mocking
+import { selectTopLocations } from '../../top/select-top-locations.selectors';
+
+// Constants for reused values
+const location1Id = 'loc1';
+const location1Name = 'Location 1';
+const location2Id = 'loc2';
+const location2Name = 'Location 2';
+
+// Create location objects that match the expected type
+const mockLocationObjects: Location[] = [
+  { id: location1Id, name: location1Name, departments: [] },
+  { id: location2Id, name: location2Name, departments: [] },
+];
+
+// Mock implementation helper that ensures the computed function is called
+function setupMockSelector(returnValue: unknown): void {
+  (selectTopLocations as unknown as jest.Mock).mockReturnValue(returnValue);
+}
+
+describe('selectLocations', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    jest.clearAllMocks();
+  });
+
+  it('should return location objects when conditions are met', () => {
+    // Set up mock for success case
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: mockLocationObjects,
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual(mockLocationObjects);
+  });
+
+  it('should handle multiple IDs', () => {
+    // Set up mock for multiple IDs
+    setupMockSelector({
+      ids: ['top1', 'top2'],
+      entities: {
+        top1: { id: 'top1', locations: mockLocationObjects },
+        top2: { id: 'top2', locations: mockLocationObjects },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle missing entity', () => {
+    // Set up mock for missing entity
+    setupMockSelector({
+      ids: ['nonExistentId'],
+      entities: {},
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty locations', () => {
+    // Set up mock for empty locations
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: [],
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle non-object locations', () => {
+    // Set up mock for string locations
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: ['not an object', 'not an object'],
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-locations.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/locations/selectors/select-locations.selector.ts
@@ -1,0 +1,27 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { computed, Signal } from '@angular/core';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { selectTopLocations } from '../../top/select-top-locations.selectors';
+
+export function selectLocations(): Signal<Location[]> {
+  return computed(function selectLocationsFunction() {
+    const tops = selectTopLocations();
+    // Instead of directly accessing .locations, we should get the full entity
+    // which will trigger the smart signal chain
+    if (tops.ids.length === 1) {
+      const topEntity = tops.entities[tops.ids[0]];
+      if (
+        topEntity &&
+        topEntity.locations.length > 0 &&
+        typeof topEntity.locations[0] === 'object'
+      ) {
+        // This will now use the smart signal chain through selectLocationsDepartments
+        return topEntity.locations as Location[];
+      }
+    }
+    return [] as Location[];
+  });
+}
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/mark-and-delete-init.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/mark-and-delete-init.ts
@@ -1,0 +1,5 @@
+export const markAndDelete = {
+  markDirtyFetchesNew: false,
+  markDirtyTime: 2 * 60 * 1000,
+  removeTime: 4 * 60 * 1000,
+};

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/selectors/select-tree-standard-signals-state.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/selectors/select-tree-standard-signals-state.selectors.ts
@@ -1,0 +1,7 @@
+import { createFeatureSelector } from '@ngrx/store';
+
+import { featureName } from '../../feature.const';
+import { TreeStandardState } from '../tree-standard-state.interface';
+
+export const selectTreeStandardSignalsState =
+  createFeatureSelector<TreeStandardState>(featureName);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/top/no-refresh-signals-top-definition.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/top/no-refresh-signals-top-definition.const.ts
@@ -1,0 +1,19 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Top } from '../../../../shared/top/top.interface';
+import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';
+import { markAndDelete } from '../mark-and-delete-init';
+
+export const noRefreshSignalsTopDefinition: SmartEntityDefinition<Top> = {
+  entityName: 'top',
+  effectServiceToken: topEffectsServiceToken,
+  markAndDelete,
+  isInitialRow: true,
+  isSignal: true,
+  defaultRow: function noRefreshTopFunction(id) {
+    return {
+      id,
+      locations: [],
+    };
+  },
+};

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/top/select-top-entities.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/top/select-top-entities.selectors.ts
@@ -1,0 +1,5 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Top } from '../../../../shared/top/top.interface';
+import { featureName } from '../../feature.const';
+export const selectTopEntities = createSmartSignal<Top>(featureName, 'top');

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/top/select-top-locations.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/top/select-top-locations.selectors.ts
@@ -1,0 +1,19 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../feature.const';
+import { selectLocationsDepartments } from '../locations/selectors/select-locations-departments.selectors';
+import { selectTopEntities } from './select-top-entities.selectors';
+
+export const selectTopLocations = createSmartSignal(selectTopEntities, [
+  {
+    childFeature: featureName,
+    childEntity: 'locations',
+    parentField: 'locations',
+    parentFeature: featureName,
+    parentEntity: 'top',
+    childSelector: selectLocationsDepartments,
+  },
+]);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/tree-standard-state.interface.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/tree-standard-state.interface.ts
@@ -1,0 +1,11 @@
+import { DepartmentChildEntity } from '../../../shared/entities/department-child-entity.type';
+import { DepartmentEntity } from '../../../shared/entities/department-entity.type';
+import { LocationEntity } from '../../../shared/entities/location-entity.type';
+import { TopEntity } from '../../../shared/entities/top-entity.type';
+
+export interface TreeStandardState {
+  top: TopEntity;
+  locations: LocationEntity;
+  departments: DepartmentEntity;
+  departmentChildren: DepartmentChildEntity;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/tree-standard-state2.interface.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/store/tree-standard-state2.interface.ts
@@ -1,0 +1,3 @@
+export interface TreeStandardState2 {
+  currentLocationId: string;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/tree.component.css
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/tree.component.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  height: 100%;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/tree.component.html
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/tree.component.html
@@ -1,0 +1,6 @@
+<dmb-tree
+  [locations$]="locations$()"
+  [locationId$]="locationId$()"
+  [location$]="location$()"
+  (locationChanged)="locationChanged($event)"
+></dmb-tree>

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/tree.component.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-refresh/tree.component.ts
@@ -1,0 +1,32 @@
+// jscpd:ignore-start
+// component is intentionally duplicated.
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { TreeComponent as SharedTreeComponent } from '../../shared/components/tree/tree.component';
+import { currentLocationSignalStore } from './store/current-location/current-location.signal-store';
+import { selectCurrentLocationSignal } from './store/current-location/select-current-location.signal';
+import { selectLocations } from './store/locations/selectors/select-locations.selector';
+@Component({
+  selector: 'dmb-demo-tree-no-refresh',
+  standalone: true,
+  imports: [CommonModule, SharedTreeComponent],
+  templateUrl: './tree.component.html',
+  styleUrls: ['./tree.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [currentLocationSignalStore],
+})
+export class TreeComponent {
+  currentLocationSignalStore = inject(currentLocationSignalStore);
+  locationId$ = this.currentLocationSignalStore.selectCurrentLocationId;
+  locations$ = selectLocations();
+
+  // Create the computed signal directly in the component
+
+  location$ = selectCurrentLocationSignal(this.currentLocationSignalStore);
+
+  locationChanged(event: string): void {
+    this.currentLocationSignalStore.setCurrentLocationId(event);
+  }
+}
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/feature.const.ts
@@ -1,0 +1,1 @@
+export const featureName = 'tree-standard';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/feature.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/feature.const.ts
@@ -1,1 +1,1 @@
-export const featureName = 'tree-standard';
+export const featureName = 'tree-no-remove';

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/current-location/current-location.signal-store.spec.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/current-location/current-location.signal-store.spec.ts
@@ -1,0 +1,139 @@
+import { TestBed } from '@angular/core/testing';
+
+// Create a simplified Location interface for testing
+interface Location {
+  id: string;
+  name: string;
+  departments: unknown[];
+}
+
+// Mock data - create before the mock
+const mockLocations: Location[] = [];
+
+// Create mock signal function that we'll use across tests
+const mockSignalFn = jest.fn().mockReturnValue(mockLocations);
+
+// Create a mock for selectLocations that we can spy on
+const mockSelectLocations = jest.fn().mockReturnValue(mockSignalFn);
+
+// Mock the module before importing
+jest.mock('../locations/selectors/select-locations.selector', () => ({
+  selectLocations: mockSelectLocations,
+}));
+
+// Now import the module under test
+import { currentLocationSignalStore } from './current-location.signal-store';
+
+describe('currentLocationSignalStore', () => {
+  let store: InstanceType<typeof currentLocationSignalStore>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [currentLocationSignalStore],
+    });
+
+    // Reset test data
+    mockLocations.length = 0;
+
+    // Clear all mock calls and implementations
+    jest.clearAllMocks();
+    mockSignalFn.mockClear();
+    mockSelectLocations.mockClear();
+
+    // Ensure the mock function returns our signal function
+    mockSelectLocations.mockReturnValue(mockSignalFn);
+
+    // Get a fresh instance of the store
+    store = TestBed.inject(currentLocationSignalStore);
+  });
+
+  describe('setCurrentLocationId', () => {
+    it('should update the currentLocationId state', () => {
+      // Initial value should be empty
+      expect(store.currentLocationId()).toBe('');
+
+      // Set a new location ID
+      store.setCurrentLocationId('location1');
+
+      // State should be updated
+      expect(store.currentLocationId()).toBe('location1');
+    });
+  });
+
+  describe('selectCurrentLocationId', () => {
+    it('should return the currentLocationId when it has a value', () => {
+      // Set up test data
+      mockLocations.push(
+        { id: 'location2', name: 'Location 2', departments: [] },
+        { id: 'location3', name: 'Location 3', departments: [] },
+      );
+
+      // Set a location ID
+      store.setCurrentLocationId('location1');
+
+      // Should prioritize the current location ID
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('location1');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return the first location ID when currentLocationId is empty and locations exist', () => {
+      // Set up test data with valid objects
+      mockLocations.push(
+        { id: 'location1', name: 'Location 1', departments: [] },
+        { id: 'location2', name: 'Location 2', departments: [] },
+      );
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('location1');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return empty string when currentLocationId is empty and locations are empty', () => {
+      // Empty locations array (default state)
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+
+    it('should return empty string when currentLocationId is empty and locations are not objects', () => {
+      // Set up non-object locations
+      const nonObjects = ['not an object', 'also not an object'];
+      // Replace mockLocations.push with direct assignment
+      mockSignalFn.mockReturnValue(nonObjects);
+
+      // Make sure current ID is empty
+      store.setCurrentLocationId('');
+
+      // Get the computed signal value
+      const result = store.selectCurrentLocationId();
+
+      // Verify results
+      expect(result).toBe('');
+
+      // Verify locations were retrieved
+      expect(mockSelectLocations).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/current-location/current-location.signal-store.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/current-location/current-location.signal-store.ts
@@ -1,0 +1,47 @@
+import { computed } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+
+import { selectLocations } from '../locations/selectors/select-locations.selector';
+import { TreeStandardState2 } from '../tree-standard-state2.interface';
+
+export const currentLocationSignalStore = signalStore(
+  { providedIn: 'root' },
+  withState({
+    currentLocationId: '',
+  } as TreeStandardState2),
+  withMethods(function withMethodsFunction(store) {
+    return {
+      setCurrentLocationId: function setCurrentLocationId(
+        currentLocationId: string,
+      ): void {
+        patchState(store, function setCurrentLocationIdPatch(state) {
+          return { ...state, currentLocationId };
+        });
+      },
+    };
+  }),
+  withComputed(function computedFunction({ currentLocationId }) {
+    const locationsSignal = selectLocations();
+
+    return {
+      selectCurrentLocationId: computed(
+        function selectCurrentLocationIdComputedFunction(): string {
+          const locations = locationsSignal();
+          if (currentLocationId().length > 0) {
+            return currentLocationId();
+          }
+          if (locations.length > 0 && typeof locations[0] === 'object') {
+            return locations[0].id;
+          }
+          return '';
+        },
+      ),
+    };
+  }),
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/current-location/select-current-location.signal.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/current-location/select-current-location.signal.ts
@@ -1,0 +1,47 @@
+import { computed, Signal } from '@angular/core';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { selectLocationsDepartments } from '../locations/selectors/select-locations-departments.selectors';
+import { currentLocationSignalStore } from './current-location.signal-store';
+
+// Define the store instance type to properly type the parameter
+type CurrentLocationStore = InstanceType<typeof currentLocationSignalStore>;
+
+export function selectCurrentLocationSignal(
+  store: CurrentLocationStore,
+): Signal<{
+  id: string;
+  name: string;
+  departments: Department[] | string[];
+}> {
+  return computed(function selectCurrentLocation() {
+    const currentLocationId = store.selectCurrentLocationId();
+
+    // First get the location with departments
+    const locationDepartmentsSignal = selectLocationsDepartments;
+    const locationState = locationDepartmentsSignal();
+
+    const location = locationState.entities[currentLocationId];
+
+    /* the if is difficult to test because it requires
+       facadeRegistry.register() to be called first which
+       is difficult to arrange in a test.
+    */
+    /* istanbul ignore if */
+    if (location) {
+      // The departments array should automatically handle its child signals
+      const departments = location.departments;
+
+      return {
+        ...location,
+        departments,
+      };
+    }
+
+    return {
+      id: '',
+      name: '',
+      departments: [],
+    };
+  });
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department-children/department-child.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department-children/department-child.selector.ts
@@ -1,0 +1,9 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
+import { featureName } from '../../feature.const';
+
+export const selectDepartmentChildren = createSmartSignal<DepartmentChild>(
+  featureName,
+  'departmentChildren',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department-children/no-remove-signals-department-children-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department-children/no-remove-signals-department-children-definition.ts
@@ -1,0 +1,26 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { DepartmentChild } from '../../../../shared/department-children/department-child.interface';
+import { departmentChildEffectsServiceToken } from '../../../../shared/department-children/department-child-effects.service-token';
+
+export const noRemoveSignalsDepartmentChildrenDefinition: SmartEntityDefinition<DepartmentChild> =
+  {
+    entityName: 'departmentChildren',
+    effectServiceToken: departmentChildEffectsServiceToken,
+    markAndDelete: {
+      markDirtyTime: 2 * 60 * 1000,
+      removeTime: 0,
+    },
+    isSignal: true,
+    defaultRow: function noRemoveDepartmentChildrenDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        children: {
+          indexes: [],
+          startIndex: 0,
+          length: 0,
+        },
+      };
+    },
+  };

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department/no-remove-signals-departments-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department/no-remove-signals-departments-definition.ts
@@ -1,0 +1,27 @@
+/* jscpd:ignore-start -- intentionally duplicated */
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { departmentEffectsServiceToken } from '../../../../shared/department/department-effects.service-token';
+
+export const noRemoveSignalsDepartmentsDefinition: SmartEntityDefinition<Department> =
+  {
+    entityName: 'departments',
+    effectServiceToken: departmentEffectsServiceToken,
+    markAndDelete: {
+      markDirtyTime: 2 * 60 * 1000,
+      removeTime: 0,
+    },
+    isSignal: true,
+    defaultRow: function noRemoveDepartmentsDefaultRowFunction(id) {
+      return {
+        id,
+        name: '',
+        children: {
+          indexes: [],
+          length: 0,
+        },
+      };
+    },
+  };
+/* jscpd:ignore-end */

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department/select-departments-children.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department/select-departments-children.selector.ts
@@ -1,0 +1,19 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../feature.const';
+import { selectDepartmentChildren } from '../department-children/department-child.selector';
+import { selectDepartments } from './select-departments.selector';
+
+export const selectDepartmentsChildren = createSmartSignal(selectDepartments, [
+  {
+    childFeature: featureName,
+    childEntity: 'departmentChildren',
+    parentFeature: featureName,
+    parentEntity: 'departments',
+    parentField: 'children',
+    childSelector: selectDepartmentChildren,
+  },
+]);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department/select-departments.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/department/select-departments.selector.ts
@@ -1,0 +1,9 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Department } from '../../../../shared/department/department.interface';
+import { featureName } from '../../feature.const';
+
+export const selectDepartments = createSmartSignal<Department>(
+  featureName,
+  'departments',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/no-remove-signals-locations-definition.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/no-remove-signals-locations-definition.ts
@@ -1,0 +1,25 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Location } from '../../../../shared/locations/location.interface';
+import { locationEffectsServiceToken } from '../../../../shared/locations/location-effects.service-token';
+
+export const noRemoveSignalsLocationsDefinition: SmartEntityDefinition<Location> =
+  {
+    entityName: 'locations',
+    effectServiceToken: locationEffectsServiceToken,
+    markAndDelete: {
+      markDirtyTime: 2 * 60 * 1000,
+      removeTime: 0,
+    },
+    isSignal: true,
+    defaultRow:
+      function noRemoveLocationsDefaultRowFunctionLocationsDefaultRowFunction(
+        id,
+      ) {
+        return {
+          id,
+          name: '',
+          departments: [],
+        };
+      },
+  };

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-location-entities.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-location-entities.selectors.ts
@@ -1,0 +1,8 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { featureName } from '../../../feature.const';
+export const selectLocationEntities = createSmartSignal<Location>(
+  featureName,
+  'locations',
+);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-locations-departments.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-locations-departments.selectors.ts
@@ -1,0 +1,22 @@
+// jscpd:ignore-start
+// intentionally duplicated because it is for different state for demo purposes
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../../feature.const';
+import { selectDepartmentsChildren } from '../../department/select-departments-children.selector';
+import { selectLocationEntities } from './select-location-entities.selectors';
+
+export const selectLocationsDepartments = createSmartSignal(
+  selectLocationEntities,
+  [
+    {
+      childFeature: featureName,
+      childEntity: 'departments',
+      parentField: 'departments',
+      parentFeature: featureName,
+      parentEntity: 'locations',
+      childSelector: selectDepartmentsChildren,
+    },
+  ],
+);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-locations.selector.spec.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-locations.selector.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { selectLocations } from './select-locations.selector';
+
+// Mock the entire module and its functions
+jest.mock('../../top/select-top-locations.selectors', () => {
+  return {
+    selectTopLocations: jest.fn(),
+  };
+});
+
+// Import after mocking
+import { selectTopLocations } from '../../top/select-top-locations.selectors';
+
+// Constants for reused values
+const location1Id = 'loc1';
+const location1Name = 'Location 1';
+const location2Id = 'loc2';
+const location2Name = 'Location 2';
+
+// Create location objects that match the expected type
+const mockLocationObjects: Location[] = [
+  { id: location1Id, name: location1Name, departments: [] },
+  { id: location2Id, name: location2Name, departments: [] },
+];
+
+// Mock implementation helper that ensures the computed function is called
+function setupMockSelector(returnValue: unknown): void {
+  (selectTopLocations as unknown as jest.Mock).mockReturnValue(returnValue);
+}
+
+describe('selectLocations', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    jest.clearAllMocks();
+  });
+
+  it('should return location objects when conditions are met', () => {
+    // Set up mock for success case
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: mockLocationObjects,
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual(mockLocationObjects);
+  });
+
+  it('should handle multiple IDs', () => {
+    // Set up mock for multiple IDs
+    setupMockSelector({
+      ids: ['top1', 'top2'],
+      entities: {
+        top1: { id: 'top1', locations: mockLocationObjects },
+        top2: { id: 'top2', locations: mockLocationObjects },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle missing entity', () => {
+    // Set up mock for missing entity
+    setupMockSelector({
+      ids: ['nonExistentId'],
+      entities: {},
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty locations', () => {
+    // Set up mock for empty locations
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: [],
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+
+  it('should handle non-object locations', () => {
+    // Set up mock for string locations
+    setupMockSelector({
+      ids: ['top1'],
+      entities: {
+        top1: {
+          id: 'top1',
+          locations: ['not an object', 'not an object'],
+        },
+      },
+    });
+
+    // Get signal and value
+    const locationsSignal = selectLocations();
+    const result = locationsSignal();
+
+    // Verify results
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-locations.selector.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/locations/selectors/select-locations.selector.ts
@@ -1,0 +1,27 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { computed, Signal } from '@angular/core';
+
+import { Location } from '../../../../../shared/locations/location.interface';
+import { selectTopLocations } from '../../top/select-top-locations.selectors';
+
+export function selectLocations(): Signal<Location[]> {
+  return computed(function selectLocationsFunction() {
+    const tops = selectTopLocations();
+    // Instead of directly accessing .locations, we should get the full entity
+    // which will trigger the smart signal chain
+    if (tops.ids.length === 1) {
+      const topEntity = tops.entities[tops.ids[0]];
+      if (
+        topEntity &&
+        topEntity.locations.length > 0 &&
+        typeof topEntity.locations[0] === 'object'
+      ) {
+        // This will now use the smart signal chain through selectLocationsDepartments
+        return topEntity.locations as Location[];
+      }
+    }
+    return [] as Location[];
+  });
+}
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/selectors/select-tree-standard-signals-state.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/selectors/select-tree-standard-signals-state.selectors.ts
@@ -1,0 +1,7 @@
+import { createFeatureSelector } from '@ngrx/store';
+
+import { featureName } from '../../feature.const';
+import { TreeStandardState } from '../tree-standard-state.interface';
+
+export const selectTreeStandardSignalsState =
+  createFeatureSelector<TreeStandardState>(featureName);

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/top/no-remove-signals-top-definition.const.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/top/no-remove-signals-top-definition.const.ts
@@ -1,0 +1,21 @@
+import { SmartEntityDefinition } from '@smarttools/smart-signals';
+
+import { Top } from '../../../../shared/top/top.interface';
+import { topEffectsServiceToken } from '../../../../shared/top/top-effects.service-token';
+
+export const noRemoveSignalsTopDefinition: SmartEntityDefinition<Top> = {
+  entityName: 'top',
+  effectServiceToken: topEffectsServiceToken,
+  isInitialRow: true,
+  markAndDelete: {
+    markDirtyTime: 2 * 60 * 1000,
+    removeTime: 0,
+  },
+  isSignal: true,
+  defaultRow: function noRemoveTopDefaultRowFunction(id) {
+    return {
+      id,
+      locations: [],
+    };
+  },
+};

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/top/select-top-entities.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/top/select-top-entities.selectors.ts
@@ -1,0 +1,5 @@
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { Top } from '../../../../shared/top/top.interface';
+import { featureName } from '../../feature.const';
+export const selectTopEntities = createSmartSignal<Top>(featureName, 'top');

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/top/select-top-locations.selectors.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/top/select-top-locations.selectors.ts
@@ -1,0 +1,19 @@
+// jscpd:ignore-start
+// intentionally duplicated.
+import { createSmartSignal } from '@smarttools/smart-signals';
+
+import { featureName } from '../../feature.const';
+import { selectLocationsDepartments } from '../locations/selectors/select-locations-departments.selectors';
+import { selectTopEntities } from './select-top-entities.selectors';
+
+export const selectTopLocations = createSmartSignal(selectTopEntities, [
+  {
+    childFeature: featureName,
+    childEntity: 'locations',
+    parentField: 'locations',
+    parentFeature: featureName,
+    parentEntity: 'top',
+    childSelector: selectLocationsDepartments,
+  },
+]);
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/tree-standard-state.interface.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/tree-standard-state.interface.ts
@@ -1,0 +1,11 @@
+import { DepartmentChildEntity } from '../../../shared/entities/department-child-entity.type';
+import { DepartmentEntity } from '../../../shared/entities/department-entity.type';
+import { LocationEntity } from '../../../shared/entities/location-entity.type';
+import { TopEntity } from '../../../shared/entities/top-entity.type';
+
+export interface TreeStandardState {
+  top: TopEntity;
+  locations: LocationEntity;
+  departments: DepartmentEntity;
+  departmentChildren: DepartmentChildEntity;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/tree-standard-state2.interface.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/store/tree-standard-state2.interface.ts
@@ -1,0 +1,3 @@
+export interface TreeStandardState2 {
+  currentLocationId: string;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/tree.component.css
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/tree.component.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  height: 100%;
+}

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/tree.component.html
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/tree.component.html
@@ -1,0 +1,6 @@
+<dmb-tree
+  [locations$]="locations$()"
+  [locationId$]="locationId$()"
+  [location$]="location$()"
+  (locationChanged)="locationChanged($event)"
+></dmb-tree>

--- a/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/tree.component.ts
+++ b/apps/demo-ngrx-signals/src/app/routes/tree-no-remove/tree.component.ts
@@ -1,0 +1,32 @@
+// jscpd:ignore-start
+// component is intentionally duplicated.
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { TreeComponent as SharedTreeComponent } from '../../shared/components/tree/tree.component';
+import { currentLocationSignalStore } from './store/current-location/current-location.signal-store';
+import { selectCurrentLocationSignal } from './store/current-location/select-current-location.signal';
+import { selectLocations } from './store/locations/selectors/select-locations.selector';
+@Component({
+  selector: 'dmb-tree-no-remove',
+  standalone: true,
+  imports: [CommonModule, SharedTreeComponent],
+  templateUrl: './tree.component.html',
+  styleUrls: ['./tree.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [currentLocationSignalStore],
+})
+export class TreeComponent {
+  currentLocationSignalStore = inject(currentLocationSignalStore);
+  locationId$ = this.currentLocationSignalStore.selectCurrentLocationId;
+  locations$ = selectLocations();
+
+  // Create the computed signal directly in the component
+
+  location$ = selectCurrentLocationSignal(this.currentLocationSignalStore);
+
+  locationChanged(event: string): void {
+    this.currentLocationSignalStore.setCurrentLocationId(event);
+  }
+}
+// jscpd:ignore-end


### PR DESCRIPTION
# Issue Number: #900 

# Body

The signal demo is not feature parity with the classic ngrx demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced three new routes: treeNoRefresh, treeNoRemove, and treeNoDirty, each with dedicated tree components and tailored reactive state management.
  - Added standalone tree components supporting reactive location and department data, with event handling for location changes.
  - Enhanced state selectors and entity definitions for locations, departments, and department children, enabling hierarchical data handling with different mark-and-delete policies.
  - Implemented styles ensuring tree components occupy full container height.

- **Bug Fixes**
  - None.

- **Tests**
  - Added comprehensive test suites for current location stores and location selectors, covering multiple scenarios and edge cases.

- **Documentation**
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->