### PR TITLE
feat: write e2e tests that verify garbage collection for smart signals

### DIFF
--- a/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-no-dirty.test.ts
+++ b/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-no-dirty.test.ts
@@ -1,0 +1,55 @@
+// jscpd:ignore-start
+// test code is intentionally duplicated
+import { expect, test } from '@playwright/test';
+import {
+  locateFirstTreeNode,
+  locateHomeLink,
+  locateOptions,
+} from '@smarttools/e2e-common';
+
+import { getFeatureEntity } from '../helpers/get-feature-entity';
+
+const featureName = 'tree-no-dirty';
+
+test.describe('Garbage collection for no dirty', () => {
+  test.setTimeout(6 * 1000 * 60);
+  test('collects garbage', async ({ page }) => {
+    await page.goto('http://localhost:4201/treeNoDirty');
+    await expect(locateOptions(page)).toHaveCount(3);
+    let locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState).toBeDefined();
+    expect(Object.keys(locationsState!.entities).length).toBe(3);
+    await expect(locateFirstTreeNode(page)).toBeVisible();
+    let departmentsState = await getFeatureEntity(
+      page,
+      featureName,
+      'departments',
+    );
+    expect(departmentsState).toBeDefined();
+    expect(Object.keys(departmentsState!.entities).length).not.toBe(0);
+    let departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState).toBeDefined();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+    await locateHomeLink(page).click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- need to wait specific time to test garbage collection
+    await page.waitForTimeout(5.5 * 1000 * 60);
+    locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState).toBeDefined();
+    expect(Object.keys(locationsState!.entities).length).toBe(0);
+    departmentsState = await getFeatureEntity(page, featureName, 'departments');
+    expect(departmentsState).toBeDefined();
+    expect(Object.keys(departmentsState!.entities).length).toBe(0);
+    departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState).toBeDefined();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+  });
+});
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-no-refresh.test.ts
+++ b/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-no-refresh.test.ts
@@ -1,0 +1,55 @@
+// jscpd:ignore-start
+// test code is intentionally duplicated
+import { expect, test } from '@playwright/test';
+import {
+  locateFirstTreeNode,
+  locateHomeLink,
+  locateOptions,
+} from '@smarttools/e2e-common';
+
+import { getFeatureEntity } from '../helpers/get-feature-entity';
+
+const featureName = 'tree-no-refresh';
+
+test.describe('Garbage collection for no refresh', () => {
+  test.setTimeout(6 * 1000 * 60);
+  test('collects garbage', async ({ page }) => {
+    await page.goto('http://localhost:4201/treeNoRefresh');
+    await expect(locateOptions(page)).toHaveCount(3);
+    let locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState).toBeDefined();
+    expect(Object.keys(locationsState!.entities).length).toBe(3);
+    await expect(locateFirstTreeNode(page)).toBeVisible();
+    let departmentsState = await getFeatureEntity(
+      page,
+      featureName,
+      'departments',
+    );
+    expect(departmentsState).toBeDefined();
+    expect(Object.keys(departmentsState!.entities).length).not.toBe(0);
+    let departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState).toBeDefined();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+    await locateHomeLink(page).click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- need to wait specific time to test garbage collection
+    await page.waitForTimeout(5.5 * 1000 * 60);
+    locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState).toBeDefined();
+    expect(Object.keys(locationsState!.entities).length).toBe(0);
+    departmentsState = await getFeatureEntity(page, featureName, 'departments');
+    expect(departmentsState).toBeDefined();
+    expect(Object.keys(departmentsState!.entities).length).toBe(0);
+    departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState).toBeDefined();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+  });
+});
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-no-remove.test.ts
+++ b/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-no-remove.test.ts
@@ -1,0 +1,55 @@
+// jscpd:ignore-start
+// test code is intentionally duplicated
+import { expect, test } from '@playwright/test';
+import {
+  locateFirstTreeNode,
+  locateHomeLink,
+  locateOptions,
+} from '@smarttools/e2e-common';
+
+import { getFeatureEntity } from '../helpers/get-feature-entity';
+
+const featureName = 'tree-no-remove';
+
+test.describe('Garbage collection for no remove', () => {
+  test.setTimeout(6 * 1000 * 60);
+  test('collects garbage', async ({ page }) => {
+    await page.goto('http://localhost:4201/treeNoRemove');
+    await expect(locateOptions(page)).toHaveCount(3);
+    let locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState).toBeDefined();
+    expect(Object.keys(locationsState!.entities).length).toBe(3);
+    await expect(locateFirstTreeNode(page)).toBeVisible();
+    let departmentsState = await getFeatureEntity(
+      page,
+      featureName,
+      'departments',
+    );
+    expect(departmentsState).toBeDefined();
+    expect(Object.keys(departmentsState!.entities).length).not.toBe(0);
+    let departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState).toBeDefined();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+    await locateHomeLink(page).click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- need to wait specific time to test garbage collection
+    await page.waitForTimeout(5.5 * 1000 * 60);
+    locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState).toBeDefined();
+    expect(Object.keys(locationsState!.entities).length).toBe(3);
+    departmentsState = await getFeatureEntity(page, featureName, 'departments');
+    expect(departmentsState).toBeDefined();
+    expect(Object.keys(departmentsState!.entities).length).not.toBe(0);
+    departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState).toBeDefined();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+  });
+});
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-standard.test.ts
+++ b/apps/demo-ngrx-signals/e2e/common/garbage-collection-for-standard.test.ts
@@ -1,0 +1,55 @@
+// jscpd:ignore-start
+// test code is intentionally duplicated
+import { expect, test } from '@playwright/test';
+import {
+  locateFirstTreeNode,
+  locateHomeLink,
+  locateOptions,
+} from '@smarttools/e2e-common';
+
+import { getFeatureEntity } from '../helpers/get-feature-entity';
+
+const featureName = 'tree-standard';
+
+test.describe('Garbage collection for standard', () => {
+  test.setTimeout(6 * 1000 * 60);
+  test('collects garbage', async ({ page }) => {
+    await page.goto('http://localhost:4201/tree');
+    await expect(locateOptions(page)).toHaveCount(3);
+    let locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState !== undefined).toBeTruthy();
+    expect(Object.keys(locationsState!.entities).length).toBe(3);
+    await expect(locateFirstTreeNode(page)).toBeVisible();
+    let departmentsState = await getFeatureEntity(
+      page,
+      featureName,
+      'departments',
+    );
+    expect(departmentsState !== undefined).toBeTruthy();
+    expect(Object.keys(departmentsState!.entities).length).not.toBe(0);
+    let departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState !== undefined).toBeTruthy();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+    await locateHomeLink(page).click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- need to wait specific time to test garbage collection
+    await page.waitForTimeout(5.5 * 1000 * 60);
+    locationsState = await getFeatureEntity(page, featureName, 'locations');
+    expect(locationsState !== undefined).toBeTruthy();
+    expect(Object.keys(locationsState!.entities).length).toBe(0);
+    departmentsState = await getFeatureEntity(page, featureName, 'departments');
+    expect(departmentsState !== undefined).toBeTruthy();
+    expect(Object.keys(departmentsState!.entities).length).toBe(0);
+    departmentChildrenState = await getFeatureEntity(
+      page,
+      featureName,
+      'departmentChildren',
+    );
+    expect(departmentChildrenState !== undefined).toBeTruthy();
+    expect(Object.keys(departmentChildrenState!.entities).length).toBe(0);
+  });
+});
+// jscpd:ignore-end

--- a/apps/demo-ngrx-signals/playwright.config.ts
+++ b/apps/demo-ngrx-signals/playwright.config.ts
@@ -3,7 +3,7 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { defineConfig, devices } from '@playwright/test';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4201';
 
 /**
  * Read environment variables from file.

--- a/apps/demo-ngrx-signals/src/app/shared/components/tree/tree.component.html
+++ b/apps/demo-ngrx-signals/src/app/shared/components/tree/tree.component.html
@@ -114,28 +114,28 @@
         <mat-menu #addMenu="matMenu">
           <button
             mat-menu-item
-            aria-label="docs"
+            aria-label="Document"
             (click)="addChild(node, 'docs')"
           >
             Document
           </button>
           <button
             mat-menu-item
-            aria-label="folders"
+            aria-label="Folder"
             (click)="addChild(node, 'folders')"
           >
             Folder
           </button>
           <button
             mat-menu-item
-            aria-label="sprint-folders"
+            aria-label="Sprint Folder"
             (click)="addChild(node, 'sprint-folders')"
           >
             Sprint Folder
           </button>
           <button
             mat-menu-item
-            aria-label="lists"
+            aria-label="List"
             (click)="addChild(node, 'lists')"
           >
             List

--- a/libs/smart-core/package.json
+++ b/libs/smart-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarttools/smart-core",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "publishConfig": {
     "access": "public"
   },

--- a/libs/smart-ngrx/package.json
+++ b/libs/smart-ngrx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarttools/smart-ngrx",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
     "@ngrx/entity": "^19.0.0"
   },
   "dependencies": {
-    "@smarttools/smart-core": "^2.0.0",
+    "@smarttools/smart-core": "^2.0.2",
     "tslib": "^2.3.0"
   },
   "keywords": [

--- a/libs/smart-signals/package.json
+++ b/libs/smart-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarttools/smart-signals",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
     "@ngrx/signals": "^19.0.0"
   },
   "dependencies": {
-    "@smarttools/smart-core": "^2.0.0",
+    "@smarttools/smart-core": "^2.0.2",
     "tslib": "^2.3.0"
   },
   "keywords": [

--- a/libs/smart-signals/src/signal-facade/signals-facade.spec.ts
+++ b/libs/smart-signals/src/signal-facade/signals-facade.spec.ts
@@ -423,39 +423,6 @@ describe('SignalsFacade', () => {
     });
 
     describe('markDirty', () => {
-      it('should not fetch new data if markDirtyFetchesNew is false', () => {
-        // Set markDirtyFetchesNew to false
-        service.markDirtyFetchesNew = false;
-
-        // Mock the entityState
-        mockEntityState.entityState.mockReturnValue({
-          entities: {
-            '1': { id: '1', name: 'test1' },
-            '2': { id: '2', name: 'test2' },
-          },
-          ids: ['1', '2'],
-        });
-
-        // Create a spy on entityRowsRegistry.register
-        const registerSpy = jest.spyOn(entityRowsRegistry, 'register');
-
-        // Create a spy on forceDirty to ensure it's not called
-        const forceDirtySpy = jest.spyOn(service, 'forceDirty');
-
-        // Call markDirty
-        service.markDirty(['1', '2']);
-
-        // Verify forceDirty was not called
-        expect(forceDirtySpy).not.toHaveBeenCalled();
-
-        // Verify register was called with the right params
-        expect(registerSpy).toHaveBeenCalledWith(
-          'testFeature',
-          'testEntity',
-          expect.any(Array),
-        );
-      });
-
       it('should fetch new data if markDirtyFetchesNew is true', () => {
         // Set markDirtyFetchesNew to true
         service.markDirtyFetchesNew = true;

--- a/libs/smart-signals/src/signal-facade/signals-facade.ts
+++ b/libs/smart-signals/src/signal-facade/signals-facade.ts
@@ -79,6 +79,15 @@ export class SignalsFacade<
   }
 
   /**
+   * Force Dirty for Signals
+   *
+   * @param ids the ids to force dirty
+   */
+  override forceDirty(ids: string[]): void {
+    this.markDirtyWithEntities(this.entityState.entityState().entities, ids);
+  }
+
+  /**
    * Mark Dirty for Signals
    *
    * @param ids the ids to mark as dirty
@@ -91,23 +100,7 @@ export class SignalsFacade<
       this.loadByIds(ids[0]);
       return;
     }
-    if (!this.markDirtyFetchesNew) {
-      this.markDirtyNoFetchWithEntities(
-        this.entityState.entityState().entities,
-        ids,
-      );
-      return;
-    }
     this.forceDirty(ids);
-  }
-
-  /**
-   * Force Dirty for Signals
-   *
-   * @param ids the ids to force dirty
-   */
-  override forceDirty(ids: string[]): void {
-    this.markDirtyWithEntities(this.entityState.entityState().entities, ids);
   }
 
   /**

--- a/libs/smart-signals/src/socket/update-entity.function.ts
+++ b/libs/smart-signals/src/socket/update-entity.function.ts
@@ -3,10 +3,12 @@
 // different it needs to be its own code
 import { Dictionary } from '@ngrx/entity';
 import {
+  entityRegistry,
   FacadeBase,
   facadeRegistry,
   featureRegistry,
   forNext,
+  isNullOrUndefined,
   SmartNgRXRowBase,
 } from '@smarttools/smart-core';
 
@@ -50,7 +52,18 @@ function forceIdDirty<T extends SmartNgRXRowBase>(
   state: Dictionary<T>,
   actionService: FacadeBase<T>,
 ): (id: string) => void {
+  const registry = entityRegistry.get(
+    actionService.feature,
+    actionService.entity,
+  );
+  const markDirtyFetchesNew = !(
+    isNullOrUndefined(registry.markAndDeleteInit.markDirtyFetchesNew) ||
+    !registry.markAndDeleteInit.markDirtyFetchesNew
+  );
   return function innerForceIdDirty(id: string) {
+    if (markDirtyFetchesNew && state[id] !== undefined) {
+      actionService.loadByIds(id);
+    }
     if (state[id] !== undefined) {
       actionService.forceDirty([id]);
     }

--- a/libs/smart-signals/src/testing.ts
+++ b/libs/smart-signals/src/testing.ts
@@ -1,1 +1,2 @@
+export * from './signal-facade/signals-facade';
 export * from '@smarttools/smart-core';


### PR DESCRIPTION
<!--
Title:
The title should be in the form of type: subject, where type is one of the following:
- build: Changes that affect the build system or external dependencies
- ci: Changes to our CI configuration files and scripts
- docs: Documentation only changes
- feat: A new feature
- fix: A bug fix
- perf: A code change that improves performance
- refactor: A code change that neither fixes a bug nor adds a feature
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **tests**: Adding missing tests or correcting existing tests

Subject:
The subject contains a succinct description of the change:

- use the imperative, present tense: "change" not "changed" nor "changes"
- don't capitalize the first letter
- no dot (.) at the end
-->

# Issue Number: #977 

# Body

Updated code so we can test signal state and added tests for the signals demo to check garbage collection and updated code for failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added multiple end-to-end tests to verify garbage collection behaviors across various tree features.
- **Bug Fixes**
  - Improved error handling and type safety in test helpers for entity state retrieval.
- **Refactor**
  - Simplified internal logic for marking entities as dirty and consolidated related behaviors.
- **Style**
  - Updated button labels in the tree component for improved accessibility and clarity.
- **Chores**
  - Updated package versions for several libraries.
  - Changed the default base URL for Playwright tests.
- **Tests**
  - Enhanced test coverage for entity update logic, particularly around conditional data fetching and dirty marking.
  - Removed a redundant test related to entity dirty marking behavior.
- **Documentation**
  - Expanded public API exports for testing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->