### PR TITLE
allows any field to be set in the RowProxy even if it does not previosly exist

### DIFF
--- a/libs/smart-core/package.json
+++ b/libs/smart-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarttools/smart-core",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/libs/smart-core/src/row-proxy/row-proxy-set.function.spec.ts
+++ b/libs/smart-core/src/row-proxy/row-proxy-set.function.spec.ts
@@ -40,12 +40,6 @@ describe('customProxySet', () => {
         /*noop*/
       });
   });
-  describe('when prop is not in target.record', () => {
-    it('should return false', () => {
-      const p = rowProxySet(facades);
-      expect(p(target!, 'c', 'd')).toBe(false);
-    });
-  });
   describe('when prop is in target.record', () => {
     describe('when target has a parentId', () => {
       beforeEach(() => {

--- a/libs/smart-core/src/row-proxy/row-proxy-set.function.ts
+++ b/libs/smart-core/src/row-proxy/row-proxy-set.function.ts
@@ -14,14 +14,12 @@ export function rowProxySet<T extends SmartNgRXRowBase>(facades: {
   facade: FacadeBase<T>;
   parentFacade: FacadeBase;
 }): (target: RowProxy<T>, prop: string | symbol, value: unknown) => boolean {
+  // eslint-disable-next-line sonarjs/no-invariant-returns -- part of the spec
   return function innerRowProxySet(
     target: RowProxy<T>,
     prop: string | symbol,
     value: unknown,
   ) {
-    if (!(prop in target.record)) {
-      return false;
-    }
     target.changes[prop] = value;
     const realRow = target.getRealRow();
     // if there is a parentId then we need to

--- a/libs/smart-ngrx/package.json
+++ b/libs/smart-ngrx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarttools/smart-ngrx",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
     "@ngrx/entity": "^19.0.0"
   },
   "dependencies": {
-    "@smarttools/smart-core": "^2.1.3",
+    "@smarttools/smart-core": "^2.1.4",
     "tslib": "^2.3.0"
   },
   "keywords": [

--- a/libs/smart-ngrx/src/integration-tests/base-array-proxy-classic-add-empty-undefined-field.integration.spec.ts
+++ b/libs/smart-ngrx/src/integration-tests/base-array-proxy-classic-add-empty-undefined-field.integration.spec.ts
@@ -1,0 +1,154 @@
+import { EnvironmentInjector, Injectable, InjectionToken } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MemoizedSelector, Store, StoreModule } from '@ngrx/store';
+import { rootInjector } from '@smarttools/smart-core';
+import { of, Subject } from 'rxjs';
+
+import {
+  createSmartSelector,
+  getTopChildRows,
+  provideSmartFeatureClassicEntities,
+  provideSmartNgRX,
+  SmartArray,
+  SmartNgRXRowBase,
+} from '../index';
+
+interface Top extends SmartNgRXRowBase {
+  id: string;
+  children: string[];
+}
+
+interface Child extends SmartNgRXRowBase {
+  id: string;
+  name: string;
+  undefinedField?: string;
+}
+
+@Injectable()
+class MockParentEffectService {
+  loadByIds(_: string[]) {
+    // Return the parent row with empty children
+    return of([{ id: '1', children: [] }]);
+  }
+}
+
+@Injectable()
+class MockChildEffectService {
+  loadByIds(_: string[]) {
+    return of([]);
+  }
+
+  add(_: Child) {
+    return of([{ id: 'c1', name: 'Child 1', undefinedField: undefined }]);
+  }
+}
+
+const parentEffectServiceToken = new InjectionToken('ParentEffectService');
+const childEffectServiceToken = new InjectionToken('ChildEffectService');
+
+const parentEntityName = 'top';
+const childEntityName = 'child';
+const featureName = 'tree-classic-add-empty';
+
+const topDefinition = {
+  entityName: parentEntityName,
+  effectServiceToken: parentEffectServiceToken,
+  isInitialRow: true,
+  defaultRow: (id: string) => ({ id, children: [] }),
+};
+
+const childDefinition = {
+  entityName: childEntityName,
+  effectServiceToken: childEffectServiceToken,
+  defaultRow: (id: string) => ({ id, name: '' }),
+};
+
+function getSelectors(): MemoizedSelector<
+  object,
+  Child[] & SmartArray<Top, Child>
+> {
+  const selectTopEntities = createSmartSelector<Top>(featureName, 'top');
+  const selectChildren = createSmartSelector<Child>(featureName, 'child');
+  const selectTopChildren = createSmartSelector(selectTopEntities, [
+    {
+      childFeature: featureName,
+      childEntity: 'child',
+      parentField: 'children',
+      parentFeature: featureName,
+      parentEntity: 'top',
+      childSelector: selectChildren,
+    },
+  ]);
+  return getTopChildRows<Top, Child>(selectTopChildren, 'children');
+}
+
+async function flushMicrotasks(times = 2): Promise<void> {
+  let p = Promise.resolve();
+  for (let i = 0; i < times; i++) {
+    p = p.then(async () => Promise.resolve());
+  }
+  return p;
+}
+
+describe('SmartArray (Classic NgRX) Integration - Add to Empty Array with undefined field', () => {
+  afterEach(() => {
+    rootInjector.set(undefined as unknown as EnvironmentInjector);
+  });
+
+  let store: Store;
+  let selectChildren: MemoizedSelector<
+    object,
+    Child[] & SmartArray<Top, Child>
+  >;
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [StoreModule.forRoot({})],
+      providers: [
+        {
+          provide: parentEffectServiceToken,
+          useClass: MockParentEffectService,
+        },
+        {
+          provide: childEffectServiceToken,
+          useClass: MockChildEffectService,
+        },
+        provideSmartNgRX(),
+        provideSmartFeatureClassicEntities(featureName, [
+          topDefinition,
+          childDefinition,
+        ]),
+      ],
+    });
+    store = TestBed.inject(Store);
+    await flushMicrotasks(4);
+    selectChildren = getSelectors();
+  });
+
+  it('should add a child to a parent using Add(...)', () => {
+    let added = false;
+    const finished = new Subject<boolean>();
+    let doneFlag = false;
+    store.select(selectChildren).subscribe((children) => {
+      if (children.add === undefined) {
+        return;
+      }
+      if (!added) {
+        children.add({ id: 'c1', name: 'Child 1' }, { id: '1', children: [] });
+        added = true;
+        return;
+      }
+      expect(children.length).toBe(1);
+      expect(children[0].id).toBe('c1');
+      expect(children[0].name).toBe('Child 1');
+      expect(children[0].undefinedField).toBeUndefined();
+      expect(() => {
+        children[0].undefinedField = 'abc';
+      }).not.toThrow();
+      if (!doneFlag) {
+        finished.next(true);
+        finished.complete();
+        doneFlag = true;
+      }
+    });
+  });
+});

--- a/libs/smart-signals/package.json
+++ b/libs/smart-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smarttools/smart-signals",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
     "@ngrx/signals": "^19.0.0"
   },
   "dependencies": {
-    "@smarttools/smart-core": "^2.1.3",
+    "@smarttools/smart-core": "^2.1.4",
     "tslib": "^2.3.0"
   },
   "keywords": [


### PR DESCRIPTION
<!--
Title:
The title should be in the form of type: subject, where type is one of the following:
- build: Changes that affect the build system or external dependencies
- ci: Changes to our CI configuration files and scripts
- docs: Documentation only changes
- feat: A new feature
- fix: A bug fix
- perf: A code change that improves performance
- refactor: A code change that neither fixes a bug nor adds a feature
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)
- **tests**: Adding missing tests or correcting existing tests

Subject:
The subject contains a succinct description of the change:

- use the imperative, present tense: "change" not "changed" nor "changes"
- don't capitalize the first letter
- no dot (.) at the end
-->

# Issue Number: #1050 

# Body

Original code only allowed updates to a row if the field was there, removed that code and now new fields can be added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an integration test to verify adding a child entity with an optional undefined field to a parent with an initially empty children array.

* **Bug Fixes**
  * Updated property setting logic to allow setting properties even if they are not present in the target record.

* **Tests**
  * Removed a test that checked for failure when setting a non-existent property.

* **Chores**
  * Bumped package versions for smart-core, smart-ngrx, and smart-signals to 2.1.4 and updated internal dependencies accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->